### PR TITLE
fix typos introduced in #24

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -272,8 +272,8 @@
         In this interaction-model, the presenting party initiates an interaction,
         notifying the receiver. The presentation receiver responds to the
         presentation intention with cryptographic material for completing the
-        presentation. This is used by the presenter for proofing the Verifiable
-        Presenting, which finally passed to the receiver. 
+        presentation. This is used by the presenter for proving the Verifiable
+        Presentation, which finally passed to the receiver. 
       </p>
 
       <p>


### PR DESCRIPTION
I'm sure of `Presentation` vs `Presenting`.  

I'm not sure of `proving` vs `proofing` in this context.