### PR TITLE
fix: address eslint issues in postman tests

### DIFF
--- a/packages/tests-postman/README.md
+++ b/packages/tests-postman/README.md
@@ -16,7 +16,7 @@ All APIs and configs will be tested with Newman/Postman, and additional settings
 
 Install package with:
 ```bash
-npm i
+npm ci
 ```
 
 This package may be executed with the following:
@@ -105,9 +105,9 @@ JSON output is available for all tests and may be combined for analytics individ
 ```bash
 ├── bin - binary folder for cli test execution and integration into CI
 ├── collections - postman collections
-│   └── reference - postman examples related to this test suite
+│   └── reference - postman examples related to this test suite
 └── data - data packages for use with the postman collections
-    └── reference - examples
+    └── reference - examples
 ```
 
 The basic test flow is outlined in the diagram below:

--- a/packages/tests-postman/index.js
+++ b/packages/tests-postman/index.js
@@ -27,8 +27,6 @@ program
     './collections/reference-credentials.json'
   );
 
-//     .option('-s, --service <file>', 'use the specified interop test collection', './collections/interop-credentials.json');
-
 program
   .option(
     '-sd, --servicedata <file>',
@@ -40,8 +38,6 @@ program
     'use the specified reference VC data collection',
     './data/reference-credentials.json'
   );
-
-  //     .option('-sd, --servicedata <file>', 'use the specified interop data collection', './data/interop-credentials.json');
 
 program.option('-rd, --reportdir <folder>', 'use the specified service provider data collection', './newman');
 program.addOption(


### PR DESCRIPTION
Address disabled eslint rules from #44.

Note that the `eslint-disable-line import/extensions` exception when importing the sha256 module is required because the default specifier resolution of "explicit" will not locate the module without the `.js` extension. An alternative would be to require `--experimental-specifier-resolution=node` on the command line when running the tests, but that seems like an unnecessary barrier to testing.