### PR TITLE
doc: add definition for workflow and correlation id

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -372,8 +372,8 @@
           Such an identifier is usually created upon the creation of the first
           node to be associated with a PATH, or upon the creation of a PATH
           (in whole or in part) after the fact.  This CORRELATION ID is attached to a
-          VC or other credentials by use of a property in the "credentialSubject" 
-          with the property name "correlationId".
+          VC, VP, or other credentials by use of a property named "correlationId" 
+          in the credential or as the domain with a presentation.
           <aside class="example" title="CORRELATIONID">
             <p>
               Use of a CORRELATION ID in a VC
@@ -386,11 +386,36 @@
                 ],
                 "type": ["VerifiableCredential"],
                 "issuer": "did:example:Wz4eUg7SetGfaUVCn8U9d62oDYrUJLuUtcy619",
+                "correlationId": "d2dfc100-9384-49e4-b547-5e7d84ec5bf5",
                 "credentialSubject": {
                   "originator": "Some User or System",
                   "product": "Blueberries",
-                  "correlationId": "d2dfc100-9384-49e4-b547-5e7d84ec5bf5"
                 }...
+            </pre>
+          </aside>
+          <aside class="example" title="CORRELATIONID">
+            <p>
+              Use of a CORRELATION ID in a VP as the domain
+            <p>
+            <pre class="js">
+              {
+                "@context": [
+                  "https://www.w3.org/2018/credentials/v1",
+                  "https://www.w3.org/2018/credentials/examples/v1"
+                ],
+                "id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
+                "type": ["VerifiablePresentation", "CredentialManagerPresentation"],
+                "verifiableCredential": [{  }],
+                "proof": {
+                  "type": "RsaSignature2018",
+                  "created": "2018-09-14T21:19:10Z",
+                  "proofPurpose": "authentication",
+                  "verificationMethod": "did:example:ebfeb1f712ebc6f1c276e12ec21#keys-1",
+                  
+                  "challenge": "1f44d55f-f161-4938-a659-f8026467f126",
+                  "domain": "d2dfc100-9384-49e4-b547-5e7d84ec5bf5"
+                }
+              }
             </pre>
           </aside>
         </dd>

--- a/docs/index.html
+++ b/docs/index.html
@@ -341,6 +341,59 @@
           <dfn data-lt="URI|URIs">URI</dfn>
         </dt>
         <dd>An identifier as defined by [[RFC3986]].</dd>
+        <dt>
+          <dfn data-lt="WORKFLOW|WORKFLOWs">WORKFLOW</dfn>
+        </dt>
+        <dd>
+          A distinct path for a distinct set of items being traced that either is declared
+          in advance by a user or system, or a root path that has already occurred
+          (in whole or in part). A WORKFLOW might branch, combine with others, or
+          terminate prematurely. It is an abstraction that in a traceability
+          context is inherently directed, and has a declared origin node,
+          and desired end node, with each node being a change in state or location.
+          Properties may be attached to nodes via credentials and correlated to one
+          another (and as a result, to the set of items) through use of a distinct
+          WORKFLOW CORRELATION ID.
+
+          In a real world context, a workflow might be created to describe one party
+          requesting a set of goods from some other location.  The workflow can then
+          be used to group and associate the nodes as those goods move from the origination
+          point (a node) to the end destination.  Any change in state, location, or 
+          control (legal or physical responsibility of some kind for the goods) would be
+          described as a node represented by a VC which has the workflow CORRELATION ID
+          attached to it. 
+        </dd>
+        <dt>
+          <dfn data-lt="CORRELATION ID|CORRELATION IDs|CORRELATIONID|CORRELATIONIDs">CORRELATION ID</dfn>
+        </dt>
+        <dd>
+          A unique identifier assigned to a WORKFLOW complying with [[RFC4122]].
+          A CORRELATION ID MUST conform with UUID Version 4.  
+          Such an identifier is usually created upon the creation of the first
+          node to be associated with a workflow, or upon the creation of a workflow
+          (in whole or in part) after the fact.  This CORRELATION ID is attached to a
+          VC or other credentials by use of a property in the "credentialSubject" 
+          with the property name "correlationId".
+          <aside class="example" title="CORRELATIONID">
+            <p>
+              Use of a CORRELATION ID in a VC
+            <p>
+            <pre class="js">
+              {
+                "@context": [
+                  "https://www.w3.org/2018/credentials/v1",
+                  "https://www.w3.org/2018/credentials/examples/v1"
+                ],
+                "type": ["VerifiableCredential"],
+                "issuer": "did:example:Wz4eUg7SetGfaUVCn8U9d62oDYrUJLuUtcy619",
+                "credentialSubject": {
+                  "workFlowOriginator": "Some User or System",
+                  "product": "Blueberries",
+                  "correlationId": "d2dfc100-9384-49e4-b547-5e7d84ec5bf5"
+                }...
+            </pre>
+          </aside>
+        </dd>
       </dl>
     </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -342,35 +342,35 @@
         </dt>
         <dd>An identifier as defined by [[RFC3986]].</dd>
         <dt>
-          <dfn data-lt="WORKFLOW|WORKFLOWs">WORKFLOW</dfn>
+          <dfn data-lt="PATH|PATHs">PATH</dfn>
         </dt>
         <dd>
           A distinct path for a distinct set of items being traced that either is declared
           in advance by a user or system, or a root path that has already occurred
-          (in whole or in part). A WORKFLOW might branch, combine with others, or
+          (in whole or in part). A PATH might branch, combine with others, or
           terminate prematurely. It is an abstraction that in a traceability
           context is inherently directed, and has a declared origin node,
           and desired end node, with each node being a change in state or location.
           Properties may be attached to nodes via credentials and correlated to one
           another (and as a result, to the set of items) through use of a distinct
-          WORKFLOW CORRELATION ID.
+          PATH CORRELATION ID.
 
-          In a real world context, a workflow might be created to describe one party
-          requesting a set of goods from some other location.  The workflow can then
+          In a real world context, a PATH might be created to describe one party
+          requesting a set of goods from some other location.  The PATH can then
           be used to group and associate the nodes as those goods move from the origination
           point (a node) to the end destination.  Any change in state, location, or 
           control (legal or physical responsibility of some kind for the goods) would be
-          described as a node represented by a VC which has the workflow CORRELATION ID
+          described as a node represented by a VC which has the PATH CORRELATION ID
           attached to it. 
         </dd>
         <dt>
           <dfn data-lt="CORRELATION ID|CORRELATION IDs|CORRELATIONID|CORRELATIONIDs">CORRELATION ID</dfn>
         </dt>
         <dd>
-          A unique identifier assigned to a WORKFLOW complying with [[RFC4122]].
+          A unique identifier assigned to a PATH complying with [[RFC4122]].
           A CORRELATION ID MUST conform with UUID Version 4.  
           Such an identifier is usually created upon the creation of the first
-          node to be associated with a workflow, or upon the creation of a workflow
+          node to be associated with a PATH, or upon the creation of a PATH
           (in whole or in part) after the fact.  This CORRELATION ID is attached to a
           VC or other credentials by use of a property in the "credentialSubject" 
           with the property name "correlationId".
@@ -387,7 +387,7 @@
                 "type": ["VerifiableCredential"],
                 "issuer": "did:example:Wz4eUg7SetGfaUVCn8U9d62oDYrUJLuUtcy619",
                 "credentialSubject": {
-                  "workFlowOriginator": "Some User or System",
+                  "originator": "Some User or System",
                   "product": "Blueberries",
                   "correlationId": "d2dfc100-9384-49e4-b547-5e7d84ec5bf5"
                 }...


### PR DESCRIPTION
First step at addressing #56 and #57
I expect these definitions to evolve, and likely shorten if we add a discrete section on workflows, which is likely needed as there is a lot of nuance there.  I have tried to keep things as simple and generic as possible to account for virtual and physical traceability, and to map terms back to common graph theory terms.