### PR TITLE
Add revocation list endpoint

### DIFF
--- a/docs/components/CredentialLinkedDataProof.yml
+++ b/docs/components/CredentialLinkedDataProof.yml
@@ -1,4 +1,4 @@
-ttile: Credential Linked Data Proof
+title: Credential Linked Data Proof
 type: object
 description: A JSON-LD Linked Data proof.
 properties:

--- a/docs/components/CredentialLinkedDataProof.yml
+++ b/docs/components/CredentialLinkedDataProof.yml
@@ -1,0 +1,29 @@
+ttile: Credential Linked Data Proof
+type: object
+description: A JSON-LD Linked Data proof.
+properties:
+  type:
+    type: string
+    description: Linked Data Signature Suite used to produce proof.
+  created:
+    type: string
+    description: Date the proof was created.
+  verificationMethod:
+    type: string
+    description: Verification Method used to verify proof.
+  proofPurpose:
+    type: string
+    description: The purpose of the proof to be used with verificationMethod.
+    enum: 
+      - assertionMethod
+  jws:
+    type: string
+    description: Detached JSON Web Signature
+example:
+  {
+    "type": "Ed25519Signature2018",
+    "created": "2020-04-02T18:28:08Z",
+    "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+    "proofPurpose": "assertionMethod",
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YtqjEYnFENT7fNW-COD0HAACxeuQxPKAmp4nIl8jYAu__6IH2FpSxv81w-l5PvE1og50tS9tH8WyXMlXyo45CA",
+  }

--- a/docs/components/RevocationListVerifiableCredential.yml
+++ b/docs/components/RevocationListVerifiableCredential.yml
@@ -1,0 +1,34 @@
+title: Revocation List Verifiable Credential
+type: object
+allOf:
+  - $ref: "./Credential.yml"
+  - type: object
+    properties:
+      proof:
+        $ref: "./CredentialLinkedDataProof.yml"
+example:
+  {
+    "@context":
+      [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://w3id.org/vc-revocation-list-2020/v1",
+      ],
+    "id": "https://api.did.actor/revocation-lists/1.json",
+    "issuer": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
+    "issuanceDate": "2010-01-01T19:23:24Z",
+    "type": ["VerifiableCredential", "RevocationList2020Credential"],
+    "credentialSubject":
+      {
+        "id": "https://api.did.actor/revocation-lists/1.json#list",
+        "type": "RevocationList2020",
+        "encodedList": "H4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC-BthKQuJI6AEA",
+      },
+    "proof":
+      {
+        "type": "Ed25519Signature2018",
+        "created": "2021-10-31T15:32:58Z",
+        "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
+        "proofPurpose": "assertionMethod",
+        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..VYhq0wja7zOpoTfBesV0Me_0Lhj2eDdbDlwGXSTpRzrHI5F1Zu1dGuRQETnBY2XGOJRgPtb8iFdbhJQhwLvHAA",
+      },
+  }

--- a/docs/issuer-service.yml
+++ b/docs/issuer-service.yml
@@ -36,6 +36,25 @@ paths:
           description: invalid input!
         "500":
           description: error!
+
+  /credentials/revocation-list/{revocation-list-file}:
+    get:
+      tags:
+        - Issuer Service
+      summary: Get Revocation List
+      operationId: getRevocationList
+      description: Get a verifiable credential revocation list
+      responses:
+        "200":
+          description: Revocation List Verifiable Credential
+          content:
+            application/json:
+              schema:
+                $ref: "./components/RevocationListVerifiableCredential.yml"
+        "400":
+          description: Client Error
+        "500":
+          description: Server Error
   /credentials/status:
     post:
       tags:

--- a/docs/issuer-service.yml
+++ b/docs/issuer-service.yml
@@ -37,7 +37,7 @@ paths:
         "500":
           description: error!
 
-  /credentials/revocation-list/{revocation-list-file}:
+  /credentials/{id}:
     get:
       tags:
         - Issuer Service

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint:docs": "eslint --ext .html docs --fix",
     "format": "lerna run format --stream",
     "format:docs": "prettier --write docs/**/*.html",
-    "test:all": "lerna run test:all --stream"
+    "test:all": "lerna run test:all --stream",
+    "serve" : "npx serve ./docs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
in our platform we host these credential at a different endpoint:

```
/credentials/{guid}
```

However if would be easy for us to update these endpoints to match whatever we agree is required for revocation interop here.

As an issuer you do need to host these files somewhere, (or trust someone else to host them and update when their status changes).

This is to start that conversation, because changing a credential status does not actually work, unless you define how to get the credential revocation list.

I updated the PR to match what we have today.