### PR TITLE
Add revocation example

### DIFF
--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -1,11 +1,11 @@
-openapi: "3.0.0"
+openapi: '3.0.0'
 info:
   version: 1.0.0
   title: Traceability Open API Interoperability Profile
   description: Identifier and Credentials APIs for DID.
   license:
     name: Apache.20
-    
+
 servers:
   - url: https://api.did.actor
 
@@ -17,31 +17,33 @@ tags:
 
 paths:
   /did.json:
-    $ref: "./resources/api-configuration.yml"
+    $ref: './resources/api-configuration.yml'
 
   /{did}:
-    $ref: "./resources/did.yml"
+    $ref: './resources/did.yml'
 
   /api/credentials/issue:
-    $ref: "./resources/credential-issuer.yml"
+    $ref: './resources/credential-issuer.yml'
+  /api/credentials/status:
+    $ref: './resources/credential-status.yml'
   /api/credentials/verify:
-    $ref: "./resources/credential-verifier.yml"
+    $ref: './resources/credential-verifier.yml'
   /credentials/{credential-id}:
-    $ref: "./resources/credential.yml"
+    $ref: './resources/credential.yml'
 
   /api/presentations/prove:
-    $ref: "./resources/presentation-prover.yml"
+    $ref: './resources/presentation-prover.yml'
   /api/presentations/verify:
-    $ref: "./resources/presentation-verifier.yml"
+    $ref: './resources/presentation-verifier.yml'
   /api/presentations/available:
-    $ref: "./resources/presentation-available.yml"
+    $ref: './resources/presentation-available.yml'
   /api/presentations/submissions:
-    $ref: "./resources/presentation-submissions.yml"
+    $ref: './resources/presentation-submissions.yml'
 
 components:
   parameters:
-    $ref: "./parameters/_index.yml"
+    $ref: './parameters/_index.yml'
   schemas:
-    $ref: "./schemas/_index.yml"
+    $ref: './schemas/_index.yml'
   responses:
-    $ref: "./responses/_index.yml"
+    $ref: './responses/_index.yml'

--- a/docs/openapi/resources/credential-status.yml
+++ b/docs/openapi/resources/credential-status.yml
@@ -1,0 +1,42 @@
+post:
+  summary: Update Status
+  operationId: updateCredentialStatus
+  description: Updates the status of an issued credential.
+  tags:
+    - Credentials
+  requestBody:
+    description: Parameters for updating the status of the issued credential.
+    content:
+      application/json:
+        schema:
+          type: object
+          description: Request for updating the status of an issued credential.
+          properties:
+            # Only credentials with an id are revocable.
+            credentialId:
+              type: string
+            credentialStatus:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  status:
+                    type: string
+          example: {
+              'credentialId': 'urn:uuid:45a44711-e457-4fa8-9b89-69fe0287c86a',
+              # // https://w3c-ccg.github.io/vc-status-rl-2020/
+              # // If the binary value of the position in the list is 1 (one),
+              # // the verifiable credential is revoked, if it is 0 (zero) it is not revoked.
+              'credentialStatus': [{ 'type': 'RevocationList2020Status', 'status': '0' }],
+            }
+  responses:
+    '200':
+      description: Credential status successfully updated
+    '400':
+      description: Bad Request
+    '404':
+      description: Credential not found
+    '500':
+      description: Internal Server Error

--- a/docs/tutorials/authenticate/README.md
+++ b/docs/tutorials/authenticate/README.md
@@ -1,0 +1,1 @@
+This tutorial describes how to obtain an access token.

--- a/docs/tutorials/revocation/README.md
+++ b/docs/tutorials/revocation/README.md
@@ -1,0 +1,6 @@
+In this tutorial, you will learn:
+
+1. issue revocable credentials
+1. verify a credential has not been revoked
+1. revoke a credential
+1. verify a credential has been revoked

--- a/docs/tutorials/revocation/revocable-credential.collection.json
+++ b/docs/tutorials/revocation/revocable-credential.collection.json
@@ -1,0 +1,251 @@
+{
+  "info": {
+    "_postman_id": "f650d61f-ef0a-4aab-9555-9646a4fa99f9",
+    "name": "VC API - Revocable Credentials",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Get Access Token For Application",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": ["pm.environment.set(\"access_token\", pm.response.json().access_token);", ""],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"audience\": \"http://localhost:8080\",\n    \"client_id\": \"{{CLIENT_ID}}\",\n    \"client_secret\": \"{{CLIENT_SECRET}}\",\n    \"grant_type\": \"client_credentials\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/oauth/token",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8080",
+          "path": ["oauth", "token"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Issue Revocable Credential",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "const verifiableCredential = pm.response.json()",
+              "pm.environment.set(\"revocable_credential\", JSON.stringify(pm.response.json(verifiableCredential)));",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "const credentialId = 'urn:uuid:' + _.random(0, 1024);",
+              "",
+              "pm.environment.set(\"revocable_credential_id\", credentialId);"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{access_token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"credential\": {\n    \"@context\": [\n      \"https://www.w3.org/2018/credentials/v1\"\n    ],\n    \"id\": \"{{revocable_credential_id}}\",\n    \"type\": [\n      \"VerifiableCredential\"\n    ],\n    \"issuer\": \"did:key:z6MkneEzjgD4Rerd14F62MmcKXY5LQsLQeY6UntTQmtSKwFh\",\n    \"issuanceDate\": \"2010-01-01T19:23:24Z\",\n    \"credentialSubject\": {\n      \"id\": \"did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn\"\n    }\n  },\n  \"options\": {\n    \"type\": \"Ed25519Signature2018\",\n    \"created\": \"2020-04-02T18:48:36Z\",\n    \"credentialStatus\": {\n      \"type\": \"RevocationList2020Status\"\n    }\n  }\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/credentials/issue",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8080",
+          "path": ["credentials", "issue"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Confirm Credential is Not Revoked",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "",
+              "",
+              "pm.test(\"should confirm credential is not revoked\", function () {",
+              "    const responseJson = pm.response.json();",
+              "    pm.expect(responseJson.checks).to.eql([",
+              "        \"proof\",",
+              "        \"credentialStatus\"",
+              "    ]);",
+              "    pm.expect(responseJson.errors).to.eql([]);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{access_token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"verifiableCredential\": {{revocable_credential}}\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/credentials/verify",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8080",
+          "path": ["credentials", "verify"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Revoke Credential",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{access_token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"credentialId\": \"{{revocable_credential_id}}\",\n  \"credentialStatus\": [{ \"type\": \"RevocationList2020Status\", \"status\": \"1\" }]\n}\n",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/credentials/status",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8080",
+          "path": ["credentials", "status"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Confirm Credential is Revoked",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "",
+              "",
+              "pm.test(\"should confirm credential is not revoked\", function () {",
+              "    const responseJson = pm.response.json();",
+              "    pm.expect(responseJson.checks).to.eql([",
+              "        \"proof\",",
+              "        \"credentialStatus\"",
+              "    ]);",
+              "    pm.expect(responseJson.errors).to.eql([",
+              "        \"proof\",",
+              "        \"credentialStatus\"",
+              "    ]);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{access_token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"verifiableCredential\": {{revocable_credential}}\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/credentials/verify",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8080",
+          "path": ["credentials", "verify"]
+        }
+      },
+      "response": []
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds (back) the `updateCredentialStatus` operation from the VC API, and includes an example postman test, that is not yet wired into CI (or usable without modification).

Transmute won't support these changes until our next release, but you can use this postman test to begin to implement your support for them.

This tool should help you understand how to implement revocation list 2020:

https://api.did.actor/issue