### PR TITLE
Add suite agility test

### DIFF
--- a/.github/workflows/regression-agility.yml
+++ b/.github/workflows/regression-agility.yml
@@ -1,0 +1,45 @@
+name: Agility
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      # See matrix of secrets...
+      # https://sbulav.github.io/terraform/github-actions-matrix-secrets/
+      matrix:
+        include:
+          - organization_did_web: TRANSMUTE_STAGING_ORGANIZATION_DID_WEB
+            client_id: TRANSMUTE_STAGING_CLIENT_ID
+            client_secret: TRANSMUTE_STAGING_CLIENT_SECRET
+            token_audience: TRANSMUTE_STAGING_TOKEN_AUDIENCE
+            token_endpoint: TRANSMUTE_STAGING_TOKEN_ENDPOINT
+            api_base_url: TRANSMUTE_STAGING_API_BASE_URL
+
+    steps:
+      - name: Begin CI...
+        uses: actions/checkout@v2
+      - name: Use Node 16
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+
+      - name: Run Tests
+        env:
+          organization_did_web: ${{secrets[matrix.organization_did_web]}}
+          client_id: ${{secrets[matrix.client_id]}}
+          client_secret: ${{secrets[matrix.client_secret]}}
+          token_audience: ${{secrets[matrix.token_audience]}}
+          token_endpoint: ${{secrets[matrix.token_endpoint]}}
+          api_base_url: ${{secrets[matrix.api_base_url]}}
+        run: |
+          npx newman run ./docs/tutorials/agility/agility.collection.json \
+          --env-var ORGANIZATION_DID_WEB=$organization_did_web \
+          --env-var CLIENT_ID=$client_id \
+          --env-var CLIENT_SECRET=$client_secret \
+          --env-var TOKEN_AUDIENCE=$token_audience \
+          --env-var TOKEN_ENDPOINT=$token_endpoint \
+          --env-var API_BASE_URL=$api_base_url \
+          --reporters cli,jsonname: Agility Tests

--- a/docs/tutorials/agility/README.md
+++ b/docs/tutorials/agility/README.md
@@ -1,0 +1,6 @@
+The purpose of this suite is to demonstrate that a vendor can support suite agility.
+
+1. Get Access Token
+1. Discover Issuer Keys
+1. Issue with key using Ed25519Signature2018
+1. Issue with key using JsonWebSignature2020

--- a/docs/tutorials/agility/agility.collection.json
+++ b/docs/tutorials/agility/agility.collection.json
@@ -1,0 +1,232 @@
+{
+	"info": {
+		"_postman_id": "2cd978e5-d4a8-403c-9e8f-035f0749d161",
+		"name": "VC API - Suite Agility",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Get Access Token",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.environment.set(\"access_token\", pm.response.json().access_token);"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"audience\": \"{{TOKEN_AUDIENCE}}\",\n    \"client_id\": \"{{CLIENT_ID}}\",\n    \"client_secret\": \"{{CLIENT_SECRET}}\",\n    \"grant_type\": \"client_credentials\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{TOKEN_ENDPOINT}}",
+					"host": [
+						"{{TOKEN_ENDPOINT}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Organization DIDs",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"const { didDocument } = pm.response.json()",
+							"pm.environment.set(\"credential_issuer_id\", didDocument.alsoKnownAs[1]);",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{access_token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{API_BASE_URL}}/identifiers/{{ORGANIZATION_DID_WEB}}",
+					"host": [
+						"{{API_BASE_URL}}"
+					],
+					"path": [
+						"identifiers",
+						"{{ORGANIZATION_DID_WEB}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Issue with Ed25519Signature2018",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"should confirm credential was issued with Ed25519Signature2018\", function () {",
+							"    const responseJson = pm.response.json();",
+							"    pm.expect(responseJson.proof.type).to.eql('Ed25519Signature2018');",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"const credentialId = 'urn:uuid:' + _.random(0, 1024);",
+							"",
+							"pm.environment.set(\"credential_id\", credentialId);"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{access_token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"credential\": {\n    \"@context\": [\n      \"https://www.w3.org/2018/credentials/v1\"\n    ],\n    \"id\": \"{{credential_id}}\",\n    \"type\": [\n      \"VerifiableCredential\"\n    ],\n    \"issuer\": \"{{credential_issuer_id}}\",\n    \"issuanceDate\": \"2010-01-01T19:23:24Z\",\n    \"credentialSubject\": {\n      \"id\": \"did:example:123\"\n    }\n  },\n  \"options\": {\n    \"type\": \"Ed25519Signature2018\",\n    \"created\": \"2020-04-02T18:48:36Z\"\n  }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{API_BASE_URL}}/credentials/issue",
+					"host": [
+						"{{API_BASE_URL}}"
+					],
+					"path": [
+						"credentials",
+						"issue"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Issue with JsonWebSignature2020",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"should confirm credential was issued with JsonWebSignature2020\", function () {",
+							"    const responseJson = pm.response.json();",
+							"    pm.expect(responseJson.proof.type).to.eql('JsonWebSignature2020');",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"const credentialId = 'urn:uuid:' + _.random(0, 1024);",
+							"",
+							"pm.environment.set(\"credential_id\", credentialId);"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{access_token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"credential\": {\n    \"@context\": [\n      \"https://www.w3.org/2018/credentials/v1\",\n      \"https://w3id.org/security/suites/jws-2020/v1\"\n    ],\n    \"id\": \"{{credential_id}}\",\n    \"type\": [\n      \"VerifiableCredential\"\n    ],\n    \"issuer\": \"{{credential_issuer_id}}\",\n    \"issuanceDate\": \"2010-01-01T19:23:24Z\",\n    \"credentialSubject\": {\n      \"id\": \"did:example:123\"\n    }\n  },\n  \"options\": {\n    \"type\": \"JsonWebSignature2020\",\n    \"created\": \"2020-04-02T18:48:36Z\"\n  }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{API_BASE_URL}}/credentials/issue",
+					"host": [
+						"{{API_BASE_URL}}"
+					],
+					"path": [
+						"credentials",
+						"issue"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}


### PR DESCRIPTION
cc @msporny this PR adds the suite agility test here.

it requires authentication to be turned on, and it makes use of a resolver endpoint... which is required to discover the issuer keys for a did:web.

Happy to explain more about that if you like.


See also this:

https://github.com/w3c-ccg/traceability-interop/blob/main/docs/discovery.md

(we are dropping support for the DIF Well Known did config in favor of did web discovery)