### PR TITLE
Add exchange tutorial

### DIFF
--- a/.github/workflows/regression-exchange.yml
+++ b/.github/workflows/regression-exchange.yml
@@ -1,0 +1,45 @@
+name: Exchange
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      # See matrix of secrets...
+      # https://sbulav.github.io/terraform/github-actions-matrix-secrets/
+      matrix:
+        include:
+          - organization_did_web: TRANSMUTE_STAGING_ORGANIZATION_DID_WEB
+            client_id: TRANSMUTE_STAGING_CLIENT_ID
+            client_secret: TRANSMUTE_STAGING_CLIENT_SECRET
+            token_audience: TRANSMUTE_STAGING_TOKEN_AUDIENCE
+            token_endpoint: TRANSMUTE_STAGING_TOKEN_ENDPOINT
+            api_base_url: TRANSMUTE_STAGING_API_BASE_URL
+
+    steps:
+      - name: Begin CI...
+        uses: actions/checkout@v2
+      - name: Use Node 16
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+
+      - name: Run Tests
+        env:
+          organization_did_web: ${{secrets[matrix.organization_did_web]}}
+          client_id: ${{secrets[matrix.client_id]}}
+          client_secret: ${{secrets[matrix.client_secret]}}
+          token_audience: ${{secrets[matrix.token_audience]}}
+          token_endpoint: ${{secrets[matrix.token_endpoint]}}
+          api_base_url: ${{secrets[matrix.api_base_url]}}
+        run: |
+          npx newman run ./docs/tutorials/exchange/exchange-tutorial.collection.json \
+          --env-var ORGANIZATION_DID_WEB=$organization_did_web \
+          --env-var CLIENT_ID=$client_id \
+          --env-var CLIENT_SECRET=$client_secret \
+          --env-var TOKEN_AUDIENCE=$token_audience \
+          --env-var TOKEN_ENDPOINT=$token_endpoint \
+          --env-var API_BASE_URL=$api_base_url \
+          --reporters cli,jsonname: Exchange Tests

--- a/docs/tutorials/exchange/README.md
+++ b/docs/tutorials/exchange/README.md
@@ -1,0 +1,8 @@
+In this tutorial we will test:
+
+1. getting an access token
+1. getting organization identifiers and their vc-api service endpoint
+1. issuing a verifiable business card for the organization and its service endpoint
+1. getting a domain and challenge from that organization
+1. singing a verifiable presentation of the verifiable business card and the domain and challenge
+1. presenting the verifiable business card to the organization, consuming the challenge.

--- a/docs/tutorials/exchange/README.md
+++ b/docs/tutorials/exchange/README.md
@@ -4,5 +4,5 @@ In this tutorial we will test:
 1. getting organization identifiers and their vc-api service endpoint
 1. issuing a verifiable business card for the organization and its service endpoint
 1. getting a domain and challenge from that organization
-1. singing a verifiable presentation of the verifiable business card and the domain and challenge
+1. signing a verifiable presentation of the verifiable business card and the domain and challenge
 1. presenting the verifiable business card to the organization, consuming the challenge.

--- a/docs/tutorials/exchange/exchange-tutorial.collection.json
+++ b/docs/tutorials/exchange/exchange-tutorial.collection.json
@@ -1,0 +1,332 @@
+{
+  "info": {
+    "_postman_id": "9a63f5d5-fbab-473e-ad4e-0f0d7de6f3a0",
+    "name": "VC API - Verifiable Business Cards",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Get Access Token",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": ["pm.environment.set(\"access_token\", pm.response.json().access_token);"],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"audience\": \"{{TOKEN_AUDIENCE}}\",\n    \"client_id\": \"{{CLIENT_ID}}\",\n    \"client_secret\": \"{{CLIENT_SECRET}}\",\n    \"grant_type\": \"client_credentials\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{TOKEN_ENDPOINT}}",
+          "host": ["{{TOKEN_ENDPOINT}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Get Organization DIDs",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "const { didDocument } = pm.response.json()",
+              "pm.environment.set(\"credential_issuer_id\", didDocument.alsoKnownAs[1]);",
+              "pm.environment.set(\"vc_api_base_url\", didDocument.services[0].serviceEndpoint);",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{access_token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{API_BASE_URL}}/identifiers/{{ORGANIZATION_DID_WEB}}",
+          "host": ["{{API_BASE_URL}}"],
+          "path": ["identifiers", "{{ORGANIZATION_DID_WEB}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Issue with VBC",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"should confirm credential was issued with Ed25519Signature2018\", function () {",
+              "    const responseJson = pm.response.json();",
+              "",
+              "    pm.environment.set(\"verifiable_credential\", JSON.stringify(responseJson));",
+              "",
+              "    pm.expect(responseJson.proof.type).to.eql('Ed25519Signature2018');",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "const credentialId = 'urn:uuid:' + _.random(0, 1024);",
+              "",
+              "pm.environment.set(\"credential_id\", credentialId);"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{access_token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"credential\": {\n  \"@context\": [\n    \"https://www.w3.org/2018/credentials/v1\",\n    \"https://w3id.org/traceability/v1\"\n  ],\n  \"id\": \"{{credential_id}}\",\n  \"name\": \"Verifiable Business Card\",\n  \"description\": \"This credential helps you receive verifiable data\",\n  \"type\": [\n    \"VerifiableCredential\",\n    \"VerifiableBusinessCard\"\n  ],\n  \"relatedLink\": [\n    {\n      \"type\": \"LinkRole\",\n      \"target\": \"{{vc_api_base_url}}/presentations/available\",\n      \"linkRelationship\": \"OrganizationSecureShareEndpoint\"\n    }\n  ],\n  \"issuer\": {\n    \"id\": \"{{credential_issuer_id}}\",\n    \"name\": \"Test Organization Issuer\"\n  },\n  \"issuanceDate\": \"2020-04-02T18:48:36Z\",\n  \"credentialSubject\": {\n    \"id\": \"{{credential_issuer_id}}\",\n    \"type\": [\n      \"Organization\",\n      \"Brand\"\n    ],\n    \"name\": \"Test Organization Subject\"\n    \n  }\n},\n  \"options\": {\n    \"type\": \"Ed25519Signature2018\",\n    \"created\": \"2020-04-02T18:48:36Z\"\n  }\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{API_BASE_URL}}/credentials/issue",
+          "host": ["{{API_BASE_URL}}"],
+          "path": ["credentials", "issue"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Get Domain and Challenge",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "const responseJson = pm.response.json();",
+              "pm.environment.set(\"domain\", responseJson.domain);",
+              "pm.environment.set(\"challenge\", responseJson.challenge);",
+              "",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [""],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{access_token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"query\": [\n    {\n      \"type\": \"QueryByExample\",\n      \"credentialQuery\": [\n        {\n          \"type\": [\n            \"VerifiableCredential\"\n          ],\n          \"reason\": \"We want to present credentials.\"\n        }\n      ]\n    }\n  ]\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{vc_api_base_url}}/presentations/available",
+          "host": ["{{vc_api_base_url}}"],
+          "path": ["presentations", "available"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Sign Presentation",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "const responseJson = pm.response.json();",
+              "pm.environment.set(\"verifiable_presentation\", JSON.stringify(responseJson));",
+              "",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [""],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{access_token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"presentation\": {\n    \"@context\": [\n      \"https://www.w3.org/2018/credentials/v1\"\n    ],\n    \"type\": [\n      \"VerifiablePresentation\"\n    ],\n    \"holder\": \"{{credential_issuer_id}}\",\n    \"verifiableCredential\": [{{verifiable_credential}}]\n  },\n  \"options\": {\n    \"domain\": \"{{domain}}\",\n    \"challenge\": \"{{challenge}}\"\n  }\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{API_BASE_URL}}/presentations/prove",
+          "host": ["{{API_BASE_URL}}"],
+          "path": ["presentations", "prove"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Submit Presenstation",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"should confirm the submission is accepted\", function () {",
+              "    const responseJson = pm.response.json();",
+              "    pm.expect(responseJson.verified).to.eql(true);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [""],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{access_token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{{verifiable_presentation}}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{vc_api_base_url}}/presentations/submissions",
+          "host": ["{{vc_api_base_url}}"],
+          "path": ["presentations", "submissions"]
+        }
+      },
+      "response": []
+    }
+  ]
+}


### PR DESCRIPTION
This tutorial shows how to issue a Verifiable Business Card for a vendor that supports the VC API.

Then get the domain and challenge from them, and sign a presentation for them, and submit the presentation.

The current flow is all with 1 party, but a subsequent flow can be created that demonstrates a multiparty exchange.