### PR TITLE
chore: update DID resolution endpoint to match postman testing

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -106,7 +106,7 @@
         }
       }
     },
-    "/{did}": {
+    "/identifiers/{did}": {
       "get": {
         "summary": "Resolve",
         "operationId": "resolve",

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -19,7 +19,7 @@ paths:
   /did.json:
     $ref: './resources/api-configuration.yml'
 
-  /{did}:
+  /identifiers/{did}:
     $ref: './resources/did.yml'
 
   /api/credentials/issue:


### PR DESCRIPTION
Spoke offline with @OR13 about updating the DID resolution endpoint path to match what is being tested in the postman tests:

- Old: `/{did}`
- New: `/identifiers/{did}`