### PR TITLE
fix: openapi.json should be up to date with latest changes in yml

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -125,7 +125,18 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Pet"
+                  "type": "object",
+                  "properties": {
+                    "didDocument": {
+                      "type": "object"
+                    },
+                    "didResolutionMetadata": {
+                      "type": "object"
+                    },
+                    "didDocumentMetadata": {
+                      "type": "object"
+                    }
+                  }
                 }
               }
             }
@@ -1026,20 +1037,6 @@
       }
     },
     "schemas": {
-      "Pet": {
-        "type": "object",
-        "properties": {
-          "didDocument": {
-            "type": "object"
-          },
-          "didResolutionMetadata": {
-            "type": "object"
-          },
-          "didDocumentMetadata": {
-            "type": "object"
-          }
-        }
-      },
       "Error": {
         "type": "object",
         "required": [


### PR DESCRIPTION
The `openapi.json` had not been recently updated. I ran `npm run preserve` to remove references to Pet and bring the file up to date.