### PR TITLE
Disable "fail-fast" for all matrix workflows

### DIFF
--- a/.github/workflows/authentication-tutorial.yml
+++ b/.github/workflows/authentication-tutorial.yml
@@ -7,6 +7,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      # Matrix paths are independent, and failure for one provider should not
+      # halt the running jobs testing another provider.
+      fail-fast: false
       # See matrix of secrets...
       # https://sbulav.github.io/terraform/github-actions-matrix-secrets/
       matrix:

--- a/.github/workflows/regression-agility.yml
+++ b/.github/workflows/regression-agility.yml
@@ -7,6 +7,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      # Matrix paths are independent, and failure for one provider should not
+      # halt the running jobs testing another provider.
+      fail-fast: false
       # See matrix of secrets...
       # https://sbulav.github.io/terraform/github-actions-matrix-secrets/
       matrix:

--- a/.github/workflows/regression-did-web-discovery.yml
+++ b/.github/workflows/regression-did-web-discovery.yml
@@ -7,6 +7,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      # Matrix paths are independent, and failure for one provider should not
+      # halt the running jobs testing another provider.
       fail-fast: false
       # See matrix of secrets...
       # https://sbulav.github.io/terraform/github-actions-matrix-secrets/

--- a/.github/workflows/regression-did-web-discovery.yml
+++ b/.github/workflows/regression-did-web-discovery.yml
@@ -7,10 +7,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       # See matrix of secrets...
       # https://sbulav.github.io/terraform/github-actions-matrix-secrets/
       matrix:
-        fail-fast: false
         include:
           - organization_did_web: MESUR_IO_PRODUCTION_ORGANIZATION_DID_WEB
             client_id: MESUR_IO_PRODUCTION_CLIENT_ID

--- a/.github/workflows/regression-did-web-discovery.yml
+++ b/.github/workflows/regression-did-web-discovery.yml
@@ -10,6 +10,7 @@ jobs:
       # See matrix of secrets...
       # https://sbulav.github.io/terraform/github-actions-matrix-secrets/
       matrix:
+        fail-fast: false
         include:
           - organization_did_web: MESUR_IO_PRODUCTION_ORGANIZATION_DID_WEB
             client_id: MESUR_IO_PRODUCTION_CLIENT_ID

--- a/.github/workflows/regression-exchange.yml
+++ b/.github/workflows/regression-exchange.yml
@@ -7,6 +7,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      # Matrix paths are independent, and failure for one provider should not
+      # halt the running jobs testing another provider.
+      fail-fast: false
       # See matrix of secrets...
       # https://sbulav.github.io/terraform/github-actions-matrix-secrets/
       matrix:

--- a/.github/workflows/regression-mtrc.yml
+++ b/.github/workflows/regression-mtrc.yml
@@ -7,6 +7,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      # Matrix paths are independent, and failure for one provider should not
+      # halt the running jobs testing another provider.
+      fail-fast: false
       # See matrix of secrets...
       # https://sbulav.github.io/terraform/github-actions-matrix-secrets/
       matrix:

--- a/.github/workflows/regression-revocation.yml
+++ b/.github/workflows/regression-revocation.yml
@@ -7,6 +7,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      # Matrix paths are independent, and failure for one provider should not
+      # halt the running jobs testing another provider.
+      fail-fast: false
       # See matrix of secrets...
       # https://sbulav.github.io/terraform/github-actions-matrix-secrets/
       matrix:

--- a/.github/workflows/regression-vc-jwt.yml
+++ b/.github/workflows/regression-vc-jwt.yml
@@ -7,6 +7,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      # Matrix paths are independent, and failure for one provider should not
+      # halt the running jobs testing another provider.
+      fail-fast: false
       # See matrix of secrets...
       # https://sbulav.github.io/terraform/github-actions-matrix-secrets/
       matrix:


### PR DESCRIPTION
The default behavior of github workflows when one path of a matrix test fails is to halt all other paths and stop the tests. In the case of this repository, that behavior is not ideal (one provider failing a test should not prevent other providers from being tested).
The solution to this issue is to disable the default `job.<job_id>.strategy.fail-fast`.