### PR TITLE
Add workflow to just build/publish OpenAPI spec

### DIFF
--- a/.github/workflows/publish-openapi-spec.yml
+++ b/.github/workflows/publish-openapi-spec.yml
@@ -3,7 +3,7 @@ name: OpenAPI
 on:
   push:
     branches:
-    - master
+    - main
     paths:
     - 'docs/openapi/**'
 

--- a/.github/workflows/publish-openapi-spec.yml
+++ b/.github/workflows/publish-openapi-spec.yml
@@ -1,0 +1,36 @@
+name: OpenAPI
+
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - 'docs/openapi/**'
+
+jobs:
+  openapi-build:
+    runs-on: ubuntu-latest
+    steps:
+
+      # Check out repo, setup node, and install dependencies.
+      # @see https://github.com/actions/setup-node#usage
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: 'npm'
+      - run: npm ci
+
+      # Build the JSON version of the OpenAPI specification from the YAML source
+      # files prior to publishing.
+      - name: Build Open API Specification JSON
+        run: npm run preserve
+
+      # Publish openapi subfolder to GitHub Pages
+      - name: Publish Open API Specification
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/openapi
+          destination_dir: openapi
+


### PR DESCRIPTION
This probably needs some testing and tweaking to ensure that

a) it works properly - holding off on this for merge freeze prior to today's call
b) other gh publishing jobs don't overwrite it  - we may want to add a `workflow_call` event and call this from the daily scheduled interop test OR modify that test to only deploy the /docs/reports subfolder.