### PR TITLE
Make issuer required when issuing credential

### DIFF
--- a/docs/openapi/index.html
+++ b/docs/openapi/index.html
@@ -9,7 +9,6 @@
   <body>
     <rapi-doc
       spec-url="./openapi.yml"
-      schema-style="table"
       show-header="true"
       show-info="true"
       allow-authentication="true"

--- a/docs/openapi/resources/credential-issuer.yml
+++ b/docs/openapi/resources/credential-issuer.yml
@@ -4,25 +4,26 @@ post:
   description: Issue a credential
   tags:
     - Credentials
-  parameters:
-    - $ref: "../parameters/header/proofType.yml"
-    - $ref: "../parameters/header/vcFormat.yml"
   requestBody:
-    description: Parameters for verifying the credential.
+    description: Parameters for issuing the credential.
     content:
       application/json:
         schema:
           type: object
           properties:
             credential:
-              $ref: "../schemas/Credential.yml"
+              $ref: '../schemas/Credential.yml'
+            options:
+              $ref: '../schemas/IssueCredentialOptions.yml'
 
   responses:
-    "201":
-      description: Expected response to a valid request
+    '201':
+      description: Resource Created
       content:
         application/json:
           schema:
-            $ref: "../schemas/SerializedVerifiableCredential.yml"
-    default:
-      $ref: "../responses/UnexpectedError.yml"
+            $ref: '../schemas/SerializedVerifiableCredential.yml'
+    '400':
+      $ref: '../responses/BadRequest.yml'
+    '500':
+      $ref: '../responses/UnexpectedError.yml'

--- a/docs/openapi/responses/BadRequest.yml
+++ b/docs/openapi/responses/BadRequest.yml
@@ -1,4 +1,4 @@
-description: Unexpected Error
+description: Bad Request
 content:
   application/json:
     schema:

--- a/docs/openapi/responses/_index.yml
+++ b/docs/openapi/responses/_index.yml
@@ -1,4 +1,6 @@
+BadRequest:
+  $ref: './BadRequest.yml'
 UnexpectedError:
-  $ref: "./UnexpectedError.yml"
+  $ref: './UnexpectedError.yml'
 NullResponse:
-  $ref: "./NullResponse.yml"
+  $ref: './NullResponse.yml'

--- a/docs/openapi/schemas/Credential.yml
+++ b/docs/openapi/schemas/Credential.yml
@@ -1,6 +1,6 @@
 type: object
 properties:
-  "@context":
+  '@context':
     type: array
     items:
       type: string
@@ -10,6 +10,14 @@ properties:
     type: array
     items:
       type: string
+  issuer:
+    description: This value MUST match the assertionMethod used to create the Verifiable Credential.
+    oneOf:
+      - type: string
+      - type: object
+        properties:
+          id:
+            type: string
   issuanceDate:
     type: string
   credentialSubject:
@@ -19,10 +27,10 @@ properties:
 
 example:
   {
-    "@context": ["https://www.w3.org/2018/credentials/v1"],
-    "id": "urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded",
-    "type": ["VerifiableCredential"],
-    "issuer": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
-    "issuanceDate": "2010-01-01T19:23:24Z",
-    "credentialSubject": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
+    '@context': ['https://www.w3.org/2018/credentials/v1'],
+    'id': 'urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded',
+    'type': ['VerifiableCredential'],
+    'issuer': 'did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn',
+    'issuanceDate': '2010-01-01T19:23:24Z',
+    'credentialSubject': 'did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn',
   }

--- a/docs/openapi/schemas/Credential.yml
+++ b/docs/openapi/schemas/Credential.yml
@@ -1,4 +1,10 @@
 type: object
+required:
+  - '@context'
+  - type
+  - issuer
+  - issuanceDate
+  - credentialSubject
 properties:
   '@context':
     description: This JSON-LD Context defining all terms in the Credential.

--- a/docs/openapi/schemas/Credential.yml
+++ b/docs/openapi/schemas/Credential.yml
@@ -1,12 +1,15 @@
 type: object
 properties:
   '@context':
+    description: This JSON-LD Context defining all terms in the Credential.
     type: array
     items:
       type: string
   id:
+    description: The IRI identifying the Credential
     type: string
   type:
+    description: The Type of the Credential
     type: array
     items:
       type: string
@@ -17,13 +20,19 @@ properties:
       - type: object
         properties:
           id:
+            description: The IRI identifying the Issuer
             type: string
   issuanceDate:
+    description: This value MUST be an XML Date Time String
     type: string
   credentialSubject:
     oneOf:
       - type: string
       - type: object
+        properties:
+          id:
+            description: The IRI identifying the Subject
+            type: string
 
 example:
   {

--- a/docs/openapi/schemas/Error.yml
+++ b/docs/openapi/schemas/Error.yml
@@ -8,3 +8,5 @@ properties:
     format: int32
   message:
     type: string
+  details:
+    type: object

--- a/docs/openapi/schemas/IssueCredentialOptions.yml
+++ b/docs/openapi/schemas/IssueCredentialOptions.yml
@@ -1,0 +1,25 @@
+title: Issue Credential Options
+type: object
+description: Options for issuing a verifiable credential
+properties:
+  type:
+    type: string
+    description: Linked Data Signature Suite or signal to use JWT.
+    enum: ['Ed25519Signature2018', 'JsonWebSignature2020', 'jwt_vc']
+  created:
+    type: string
+    description: Date the proof was created.
+  credentialStatus:
+    type: object
+    description: The method of credential status.
+    properties:
+      type:
+        type: string
+        description: The type of credential status.
+        enum: ['RevocationList2020Status']
+example:
+  {
+    'type': 'JsonWebSignature2020',
+    'created': '2020-04-02T18:28:08Z',
+    'credentialStatus': { 'type': 'RevocationList2020Status' },
+  }

--- a/docs/openapi/schemas/Presentation.yml
+++ b/docs/openapi/schemas/Presentation.yml
@@ -1,7 +1,10 @@
 title: Presentation
 type: object
+required:
+  - '@context'
+  - type
 properties:
-  "@context":
+  '@context':
     type: array
     items:
       type: string
@@ -16,29 +19,29 @@ properties:
   verifiableCredential:
     type: array
     items:
-      $ref: "./SerializedVerifiableCredential.yml"
+      $ref: './SerializedVerifiableCredential.yml'
 
 example:
   {
-    "@context": ["https://www.w3.org/2018/credentials/v1"],
-    "type": ["VerifiablePresentation"],
-    "holder": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
-    "verifiableCredential":
+    '@context': ['https://www.w3.org/2018/credentials/v1'],
+    'type': ['VerifiablePresentation'],
+    'holder': 'did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn',
+    'verifiableCredential':
       [
         {
-          "@context": ["https://www.w3.org/2018/credentials/v1"],
-          "id": "urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded",
-          "type": ["VerifiableCredential"],
-          "issuer": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
-          "issuanceDate": "2010-01-01T19:23:24Z",
-          "credentialSubject": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
-          "proof":
+          '@context': ['https://www.w3.org/2018/credentials/v1'],
+          'id': 'urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded',
+          'type': ['VerifiableCredential'],
+          'issuer': 'did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn',
+          'issuanceDate': '2010-01-01T19:23:24Z',
+          'credentialSubject': 'did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn',
+          'proof':
             {
-              "type": "Ed25519Signature2018",
-              "created": "2021-10-30T19:16:30Z",
-              "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
-              "proofPurpose": "assertionMethod",
-              "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..puetBYS3pkYlYzAecBiT-WkigYAlVbslrz9wPFnk9JW4AwjrpJvcsSdZJPhZtNy_myMJUNzC_QaYyw3ni1V0BA",
+              'type': 'Ed25519Signature2018',
+              'created': '2021-10-30T19:16:30Z',
+              'verificationMethod': 'did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn',
+              'proofPurpose': 'assertionMethod',
+              'jws': 'eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..puetBYS3pkYlYzAecBiT-WkigYAlVbslrz9wPFnk9JW4AwjrpJvcsSdZJPhZtNy_myMJUNzC_QaYyw3ni1V0BA',
             },
         },
       ],

--- a/docs/openapi/schemas/RevocationListCredential.yml
+++ b/docs/openapi/schemas/RevocationListCredential.yml
@@ -1,34 +1,32 @@
 title: Revocation List Verifiable Credential
 type: object
 allOf:
-  - $ref: "./Credential.yml"
+  - $ref: './Credential.yml'
   - type: object
     properties:
       proof:
-        $ref: "./CredentialLinkedDataProof.yml"
+        $ref: './CredentialLinkedDataProof.yml'
+required:
+  - id
 example:
   {
-    "@context":
-      [
-        "https://www.w3.org/2018/credentials/v1",
-        "https://w3id.org/vc-revocation-list-2020/v1",
-      ],
-    "id": "https://api.did.actor/revocation-lists/1.json",
-    "issuer": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
-    "issuanceDate": "2010-01-01T19:23:24Z",
-    "type": ["VerifiableCredential", "RevocationList2020Credential"],
-    "credentialSubject":
+    '@context': ['https://www.w3.org/2018/credentials/v1', 'https://w3id.org/vc-revocation-list-2020/v1'],
+    'id': 'https://api.did.actor/revocation-lists/1.json',
+    'issuer': 'did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn',
+    'issuanceDate': '2010-01-01T19:23:24Z',
+    'type': ['VerifiableCredential', 'RevocationList2020Credential'],
+    'credentialSubject':
       {
-        "id": "https://api.did.actor/revocation-lists/1.json#list",
-        "type": "RevocationList2020",
-        "encodedList": "H4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC-BthKQuJI6AEA",
+        'id': 'https://api.did.actor/revocation-lists/1.json#list',
+        'type': 'RevocationList2020',
+        'encodedList': 'H4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC-BthKQuJI6AEA',
       },
-    "proof":
+    'proof':
       {
-        "type": "Ed25519Signature2018",
-        "created": "2021-10-31T15:32:58Z",
-        "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
-        "proofPurpose": "assertionMethod",
-        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..VYhq0wja7zOpoTfBesV0Me_0Lhj2eDdbDlwGXSTpRzrHI5F1Zu1dGuRQETnBY2XGOJRgPtb8iFdbhJQhwLvHAA",
+        'type': 'Ed25519Signature2018',
+        'created': '2021-10-31T15:32:58Z',
+        'verificationMethod': 'did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn',
+        'proofPurpose': 'assertionMethod',
+        'jws': 'eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..VYhq0wja7zOpoTfBesV0Me_0Lhj2eDdbDlwGXSTpRzrHI5F1Zu1dGuRQETnBY2XGOJRgPtb8iFdbhJQhwLvHAA',
       },
   }


### PR DESCRIPTION
Related conversations:

- https://github.com/w3c-ccg/vc-api/issues/274
- https://github.com/w3c-ccg/vc-api/issues/266
- https://github.com/w3c-ccg/vc-api/issues/267
- https://github.com/w3c-ccg/vc-api/issues/265

In order to merge this pull request, we need unanimous agreement to the following:

1. That a 400 error shall be thrown for all attempts to issuer a credential without providing an issuer.
2. That a 201 shall be returned when the requested issuer can be used to sign the credential