### PR TITLE
Fix Warnings in Respec Document

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -287,7 +287,7 @@
 
       <dl class="termlist">
         <dt>
-          <dfn data-lt="entities|entity's">entity</dfn>
+          entity
         </dt>
         <dd>
           A thing with distinct and independent existence, such as a person,
@@ -295,18 +295,18 @@
           ecosystem.
         </dd>
         <dt>
-          <dfn>user agent</dfn>
+          user agent
         </dt>
         <dd>
           A program, such as a browser or other Web client, that mediates the
           communication between the various roles in this specification.
         </dd>
         <dt>
-          <dfn data-lt="URI|URIs">URI</dfn>
+          URI
         </dt>
         <dd>An identifier as defined by [[RFC3986]].</dd>
         <dt>
-          <dfn data-lt="CORRELATION ID|CORRELATION IDs|CORRELATIONID|CORRELATIONIDs">CORRELATION ID</dfn>
+          CORRELATION ID
         </dt>
         <dd>
 
@@ -330,7 +330,7 @@
           </aside>
         </dd>
         <dt>
-          <dfn data-lt="WorkflowDefinition">Workflow Definition</dfn>
+          Workflow Definition
         </dt>
         <dd>
           <p>
@@ -370,7 +370,7 @@
             </pre>
         </dd>
         <dt>
-          <dfn data-lt="WorkflowInstance">Workflow Instance</dfn>
+          Workflow Instance
         </dt>
         <dd>
           <p>
@@ -409,7 +409,7 @@
             </pre>
         </dd>
         <dt>
-          <dfn data-lt="PATH|PATHs">PATH</dfn>
+          PATH
         </dt>
         <dd>
           <p>


### PR DESCRIPTION
Fixes thew warnings that appear in the top right hand corner of the respec document. 
`<dfn>` tag is created but never linked to. 