### PR TITLE
fix: keep variables in collection only

### DIFF
--- a/.github/workflows/regression-workflow-instance-join.yml
+++ b/.github/workflows/regression-workflow-instance-join.yml
@@ -60,7 +60,7 @@ jobs:
           org_3_client_id: ${{secrets[matrix.org_3_client_id]}}
           org_3_client_secret: ${{secrets[matrix.org_3_client_secret]}}
         run: |
-          npx newman run ./docs/tutorials/workflow-join/ecommerce-workflow-instance-join.collection.json \
+          npx newman run ./docs/tutorials/workflow-join/workflow-instance-join.collection.json \
           --env-var ORG_1_TOKEN_ENDPOINT=$org_1_token_endpoint \
           --env-var ORG_1_TOKEN_AUDIENCE=$org_1_token_audience \
           --env-var ORG_1_BASE_URL=$org_1_api_base_url \

--- a/docs/tutorials/workflow-join/workflow-instance-join.collection.json
+++ b/docs/tutorials/workflow-join/workflow-instance-join.collection.json
@@ -1,28 +1,36 @@
 {
 	"info": {
-		"_postman_id": "6f3afe3d-f721-48df-82f7-eb3d3936f320",
-		"name": "eCommerce - Workflow Instance Join",
+		"_postman_id": "c0814470-0c07-43ad-9ed4-2ad4b125c937",
+		"name": "Workflow Instance Join",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
-			"name": "00 - Importer Access Token",
+			"name": "Get Access Token",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
-							"pm.environment.set(\"org_1_access_token\", pm.response.json().access_token);",
-							"",
 							"pm.test(\"Importer application has access token\", function () {",
 							"    pm.response.to.have.status(200);",
-							"});"
+							"});",
+							"",
+							"pm.test(\"`org_1_access_token` persisted to collectionVariables\", function() {",
+							"    const { access_token } = pm.response.json()",
+							"    pm.collectionVariables.set(\"org_1_access_token\", access_token);",
+							"});",
+							"",
+							""
 						],
 						"type": "text/javascript"
 					}
 				}
 			],
 			"request": {
+				"auth": {
+					"type": "noauth"
+				},
 				"method": "POST",
 				"header": [
 					{
@@ -50,23 +58,31 @@
 			"response": []
 		},
 		{
-			"name": "00 - Freight Forwarder Access Token",
+			"name": "Get Access Token",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
-							"pm.environment.set(\"org_2_access_token\", pm.response.json().access_token);",
-							"",
-							"pm.test(\"Freight Forwarder application has access token\", function () {",
+							"pm.test(\"Importer application has access token\", function () {",
 							"    pm.response.to.have.status(200);",
-							"});"
+							"});",
+							"",
+							"pm.test(\"`org_2_access_token` persisted to collectionVariables\", function() {",
+							"    const { access_token } = pm.response.json()",
+							"    pm.collectionVariables.set(\"org_2_access_token\", access_token);",
+							"});",
+							"",
+							""
 						],
 						"type": "text/javascript"
 					}
 				}
 			],
 			"request": {
+				"auth": {
+					"type": "noauth"
+				},
 				"method": "POST",
 				"header": [
 					{
@@ -94,23 +110,31 @@
 			"response": []
 		},
 		{
-			"name": "00 - Customs Access Token",
+			"name": "Get Access Token",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
-							"pm.environment.set(\"org_3_access_token\", pm.response.json().access_token);",
-							"",
-							"pm.test(\"Customs application has access token\", function () {",
+							"pm.test(\"Importer application has access token\", function () {",
 							"    pm.response.to.have.status(200);",
-							"});"
+							"});",
+							"",
+							"pm.test(\"`org_3_access_token` persisted to collectionVariables\", function() {",
+							"    const { access_token } = pm.response.json()",
+							"    pm.collectionVariables.set(\"org_3_access_token\", access_token);",
+							"});",
+							"",
+							""
 						],
 						"type": "text/javascript"
 					}
 				}
 			],
 			"request": {
+				"auth": {
+					"type": "noauth"
+				},
 				"method": "POST",
 				"header": [
 					{
@@ -138,22 +162,22 @@
 			"response": []
 		},
 		{
-			"name": "00 - Get Importer Exchange Endpoint",
+			"name": "Get Organization DIDs",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
 							"const { didDocument } = pm.response.json()",
-							"pm.environment.set(\"org_1_holder\", didDocument.alsoKnownAs[1]);",
-							"pm.environment.set(\"org_1_tenant_url\", didDocument.service[0].serviceEndpoint);",
+							"pm.collectionVariables.set(\"org_1_holder\", didDocument.alsoKnownAs[1]);",
+							"pm.collectionVariables.set(\"org_1_tenant_url\", didDocument.service[0].serviceEndpoint);",
 							"",
 							"pm.test(\"Importer has holder DID\", function () {",
-							"     pm.expect(pm.environment.get(\"org_1_holder\")).to.not.be.undefined;",
+							"     pm.expect(pm.collectionVariables.get(\"org_1_holder\")).to.not.be.undefined;",
 							"});",
 							"",
 							"pm.test(\"Importer has service endpoint\", function () {",
-							"     pm.expect(pm.environment.get(\"org_1_tenant_url\")).to.not.be.undefined;",
+							"     pm.expect(pm.collectionVariables.get(\"org_1_tenant_url\")).to.not.be.undefined;",
 							"});"
 						],
 						"type": "text/javascript"
@@ -193,22 +217,22 @@
 			"response": []
 		},
 		{
-			"name": "00 - Get Freight Forwarder Exchange Endpoint",
+			"name": "Get Organization DIDs",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
 							"const { didDocument } = pm.response.json()",
-							"pm.environment.set(\"org_2_holder\", didDocument.alsoKnownAs[1]);",
-							"pm.environment.set(\"org_2_tenant_url\", didDocument.service[0].serviceEndpoint);",
+							"pm.collectionVariables.set(\"org_2_holder\", didDocument.alsoKnownAs[1]);",
+							"pm.collectionVariables.set(\"org_2_tenant_url\", didDocument.service[0].serviceEndpoint);",
 							"",
 							"pm.test(\"Freight Forwarder has holder DID\", function () {",
-							"     pm.expect(pm.environment.get(\"org_2_holder\")).to.not.be.undefined;",
+							"     pm.expect(pm.collectionVariables.get(\"org_2_holder\")).to.not.be.undefined;",
 							"});",
 							"",
 							"pm.test(\"Freight Forwarder has service endpoint\", function () {",
-							"     pm.expect(pm.environment.get(\"org_2_tenant_url\")).to.not.be.undefined;",
+							"     pm.expect(pm.collectionVariables.get(\"org_2_tenant_url\")).to.not.be.undefined;",
 							"});"
 						],
 						"type": "text/javascript"
@@ -248,22 +272,22 @@
 			"response": []
 		},
 		{
-			"name": "00 - Get Customs Exchange Endpoint",
+			"name": "Get Organization DIDs",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
 							"const { didDocument } = pm.response.json()",
-							"pm.environment.set(\"org_3_holder\", didDocument.alsoKnownAs[0]);",
-							"pm.environment.set(\"org_3_tenant_url\", didDocument.service[0].serviceEndpoint);",
+							"pm.collectionVariables.set(\"org_3_holder\", didDocument.alsoKnownAs[0]);",
+							"pm.collectionVariables.set(\"org_3_tenant_url\", didDocument.service[0].serviceEndpoint);",
 							"",
 							"pm.test(\"Customs has holder DID\", function () {",
-							"     pm.expect(pm.environment.get(\"org_3_holder\")).to.not.be.undefined;",
+							"     pm.expect(pm.collectionVariables.get(\"org_3_holder\")).to.not.be.undefined;",
 							"});",
 							"",
 							"pm.test(\"Customs has service endpoint\", function () {",
-							"     pm.expect(pm.environment.get(\"org_3_tenant_url\")).to.not.be.undefined;",
+							"     pm.expect(pm.collectionVariables.get(\"org_3_tenant_url\")).to.not.be.undefined;",
 							"});"
 						],
 						"type": "text/javascript"
@@ -303,7 +327,7 @@
 			"response": []
 		},
 		{
-			"name": "01 - Importer - Issue Proforma Invoice",
+			"name": "Issue Credential",
 			"event": [
 				{
 					"listen": "test",
@@ -311,7 +335,7 @@
 						"exec": [
 							"  pm.test(\"Proforma Invoice VC issued\", function () {",
 							"      pm.response.to.have.status(201);",
-							"      pm.environment.set('importers_proforma_invoice_vc', JSON.stringify(pm.response.json()));",
+							"      pm.collectionVariables.set('importers_proforma_invoice_vc', JSON.stringify(pm.response.json()));",
 							"  })"
 						],
 						"type": "text/javascript"
@@ -354,15 +378,15 @@
 			"response": []
 		},
 		{
-			"name": "02 - Importer - Present to Customs - (1/3)",
+			"name": "Initiate Exchange",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
 							"const responseJson = pm.response.json();",
-							"pm.environment.set(\"org_3_domain\", responseJson.domain);",
-							"pm.environment.set(\"org_3_challenge\", responseJson.challenge);",
+							"pm.collectionVariables.set(\"org_3_domain\", responseJson.domain);",
+							"pm.collectionVariables.set(\"org_3_challenge\", responseJson.challenge);",
 							"",
 							"pm.test(\"Importer has authenticated to Customs\", function () {",
 							"    pm.response.to.have.status(200);",
@@ -416,14 +440,14 @@
 			"response": []
 		},
 		{
-			"name": "02 - Importer - Present to Customs - (2/3)",
+			"name": "Sign Presentation",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
 							"const responseJson = pm.response.json();",
-							"pm.environment.set(\"importers_proforma_invoice_presented_to_customs\", JSON.stringify(responseJson));",
+							"pm.collectionVariables.set(\"importers_proforma_invoice_presented_to_customs\", JSON.stringify(responseJson));",
 							"",
 							"pm.test(\"Importer VP of Proforma Invoice with workflow instance 'instance_1' proved\", function () {",
 							"    pm.response.to.have.status(201);",
@@ -484,7 +508,7 @@
 			"response": []
 		},
 		{
-			"name": "02 - Importer - Present to Customs - (3/3)",
+			"name": "Complete Exchange",
 			"event": [
 				{
 					"listen": "test",
@@ -551,7 +575,7 @@
 			"response": []
 		},
 		{
-			"name": "03 - Customs - Verify Proforma Invoice",
+			"name": "Verify Credential",
 			"event": [
 				{
 					"listen": "test",
@@ -561,10 +585,10 @@
 							"    pm.response.to.have.status(200);",
 							"});",
 							"",
-							"var workflowInstances = JSON.parse(pm.environment.get(\"importers_proforma_invoice_presented_to_customs\")).workflow.instance",
+							"var workflowInstances = JSON.parse(pm.collectionVariables.get(\"importers_proforma_invoice_presented_to_customs\")).workflow.instance",
 							"",
 							"pm.test(\"Customs stores first workflow instance id: \" + workflowInstances[0], function () {",
-							"    pm.environment.set(\"customs_first_workflow_instance_id\", workflowInstances[0]);",
+							"    pm.collectionVariables.set(\"customs_first_workflow_instance_id\", workflowInstances[0]);",
 							"});",
 							"",
 							""
@@ -609,7 +633,7 @@
 			"response": []
 		},
 		{
-			"name": "04 - Freight Forwarder - Issue House Waybill",
+			"name": "Issue Credential",
 			"event": [
 				{
 					"listen": "test",
@@ -617,7 +641,7 @@
 						"exec": [
 							"  pm.test(\"House Bill of Lading VC issued\", function () {",
 							"      pm.response.to.have.status(201);",
-							"      pm.environment.set('freight_forwarders_hbol_vc', JSON.stringify(pm.response.json()));",
+							"      pm.collectionVariables.set('freight_forwarders_hbol_vc', JSON.stringify(pm.response.json()));",
 							"  })"
 						],
 						"type": "text/javascript"
@@ -660,15 +684,15 @@
 			"response": []
 		},
 		{
-			"name": "05 - Freight Forwarder - Present to Customs - (1/3)",
+			"name": "Initiate Exchange",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
 							"const responseJson = pm.response.json();",
-							"pm.environment.set(\"org_3_domain\", responseJson.domain);",
-							"pm.environment.set(\"org_3_challenge\", responseJson.challenge);",
+							"pm.collectionVariables.set(\"org_3_domain\", responseJson.domain);",
+							"pm.collectionVariables.set(\"org_3_challenge\", responseJson.challenge);",
 							"",
 							"pm.test(\"Freight Forwarder has authenticated to Customs\", function () {",
 							"    pm.response.to.have.status(200);",
@@ -722,14 +746,14 @@
 			"response": []
 		},
 		{
-			"name": "05 - Freight Forwarder - Present to Customs - (2/3)",
+			"name": "Sign Presentation",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
 							"const responseJson = pm.response.json();",
-							"pm.environment.set(\"freight_forwarders_house_bill_presented_to_customs\", JSON.stringify(responseJson));",
+							"pm.collectionVariables.set(\"freight_forwarders_house_bill_presented_to_customs\", JSON.stringify(responseJson));",
 							"",
 							"pm.test(\"Freight Forwarder VP of House Bill of Lading with workflow instance 'instance_2' proved\", function () {",
 							"    pm.response.to.have.status(201);",
@@ -790,7 +814,7 @@
 			"response": []
 		},
 		{
-			"name": "05 - Freight Forwarder - Present to Customs - (3/3)",
+			"name": "Complete Exchange",
 			"event": [
 				{
 					"listen": "test",
@@ -857,7 +881,7 @@
 			"response": []
 		},
 		{
-			"name": "06 - Customs - Verify House Waybill",
+			"name": "Verify Credential",
 			"event": [
 				{
 					"listen": "test",
@@ -867,10 +891,10 @@
 							"    pm.response.to.have.status(200);",
 							"});",
 							"",
-							"var workflowInstances = JSON.parse(pm.environment.get(\"freight_forwarders_house_bill_presented_to_customs\")).workflow.instance",
+							"var workflowInstances = JSON.parse(pm.collectionVariables.get(\"freight_forwarders_house_bill_presented_to_customs\")).workflow.instance",
 							"",
 							"pm.test(\"Customs stores first workflow instance id: \" + workflowInstances[0], function () {",
-							"    pm.environment.set(\"customs_second_workflow_instance_id\", workflowInstances[0]);",
+							"    pm.collectionVariables.set(\"customs_second_workflow_instance_id\", workflowInstances[0]);",
 							"});",
 							""
 						],
@@ -914,7 +938,7 @@
 			"response": []
 		},
 		{
-			"name": "07 - Importer - Issue Commercial Invoice",
+			"name": "Issue Credential",
 			"event": [
 				{
 					"listen": "test",
@@ -922,7 +946,7 @@
 						"exec": [
 							"  pm.test(\"Commercial Invoice VC issued\", function () {",
 							"      pm.response.to.have.status(201);",
-							"      pm.environment.set('importers_commercial_invoice_vc', JSON.stringify(pm.response.json()));",
+							"      pm.collectionVariables.set('importers_commercial_invoice_vc', JSON.stringify(pm.response.json()));",
 							"  })"
 						],
 						"type": "text/javascript"
@@ -965,15 +989,15 @@
 			"response": []
 		},
 		{
-			"name": "08 - Importer - Present to Freight Forwarder - (1/3)",
+			"name": "Initiate Exchange",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
 							"const responseJson = pm.response.json();",
-							"pm.environment.set(\"org_2_domain\", responseJson.domain);",
-							"pm.environment.set(\"org_2_challenge\", responseJson.challenge);",
+							"pm.collectionVariables.set(\"org_2_domain\", responseJson.domain);",
+							"pm.collectionVariables.set(\"org_2_challenge\", responseJson.challenge);",
 							"",
 							"pm.test(\"Importer has authenticated to Freight Forwarder\", function () {",
 							"    pm.response.to.have.status(200);",
@@ -1027,14 +1051,14 @@
 			"response": []
 		},
 		{
-			"name": "08 - Importer - Present to Freight Forwarder - (2/3)",
+			"name": "Sign Presentation",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
 							"const responseJson = pm.response.json();",
-							"pm.environment.set(\"importers_presentation_of_ci_to_freight_forwarder\", JSON.stringify(responseJson));",
+							"pm.collectionVariables.set(\"importers_presentation_of_ci_to_freight_forwarder\", JSON.stringify(responseJson));",
 							"",
 							"pm.test(\"Importer VP of Commercial Invoice with workflow instance 'instance_1' proved\", function () {",
 							"    pm.response.to.have.status(201);",
@@ -1095,7 +1119,7 @@
 			"response": []
 		},
 		{
-			"name": "08 - Importer - Present to Freight Forwarder - (3/3)",
+			"name": "Complete Exchange",
 			"event": [
 				{
 					"listen": "test",
@@ -1162,15 +1186,15 @@
 			"response": []
 		},
 		{
-			"name": "09 - Freight Forwarder - Present to Customs - (1/3)",
+			"name": "Initiate Exchange",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
 							"const responseJson = pm.response.json();",
-							"pm.environment.set(\"org_3_domain\", responseJson.domain);",
-							"pm.environment.set(\"org_3_challenge\", responseJson.challenge);",
+							"pm.collectionVariables.set(\"org_3_domain\", responseJson.domain);",
+							"pm.collectionVariables.set(\"org_3_challenge\", responseJson.challenge);",
 							"",
 							"pm.test(\"Freight Forwarder has authenticated to Customs\", function () {",
 							"    pm.response.to.have.status(200);",
@@ -1224,14 +1248,14 @@
 			"response": []
 		},
 		{
-			"name": "09 - Freight Forwarder - Present to Customs - (2/3)",
+			"name": "Sign Presentation",
 			"event": [
 				{
 					"listen": "test",
 					"script": {
 						"exec": [
 							"const responseJson = pm.response.json();",
-							"pm.environment.set(\"freight_forwarders_presentation_of_ci_to_customs\", JSON.stringify(responseJson));",
+							"pm.collectionVariables.set(\"freight_forwarders_presentation_of_ci_to_customs\", JSON.stringify(responseJson));",
 							"",
 							"pm.test(\"Freight Forwarder VP of Commercial Invoice with workflow instances 'instance_1' and 'instance_2' proved\", function () {",
 							"    pm.response.to.have.status(201);",
@@ -1292,7 +1316,7 @@
 			"response": []
 		},
 		{
-			"name": "09 - Freight Forwarder - Present to Customs - (3/3)",
+			"name": "Complete Exchange",
 			"event": [
 				{
 					"listen": "test",
@@ -1359,7 +1383,7 @@
 			"response": []
 		},
 		{
-			"name": "10 - Customs - Verify Commercial Invoice and Join Instances",
+			"name": "Join Workflow Graphs",
 			"event": [
 				{
 					"listen": "test",
@@ -1369,11 +1393,11 @@
 							"    pm.response.to.have.status(200);",
 							"});",
 							"",
-							"var workflowInstances = JSON.parse(pm.environment.get(\"freight_forwarders_presentation_of_ci_to_customs\")).workflow.instance",
+							"var workflowInstances = JSON.parse(pm.collectionVariables.get(\"freight_forwarders_presentation_of_ci_to_customs\")).workflow.instance",
 							"",
 							"pm.test(\"Customs checks known workflow instance ids and join the workflows\", function () {",
-							"    pm.expect(workflowInstances[0]).to.eql(pm.environment.get(\"customs_first_workflow_instance_id\"));",
-							"    pm.expect(workflowInstances[1]).to.eql(pm.environment.get(\"customs_second_workflow_instance_id\"));",
+							"    pm.expect(workflowInstances[0]).to.eql(pm.collectionVariables.get(\"customs_first_workflow_instance_id\"));",
+							"    pm.expect(workflowInstances[1]).to.eql(pm.collectionVariables.get(\"customs_second_workflow_instance_id\"));",
 							"});",
 							""
 						],
@@ -1415,6 +1439,96 @@
 				}
 			},
 			"response": []
+		}
+	],
+	"variable": [
+		{
+			"key": "org_1_access_token",
+			"value": ""
+		},
+		{
+			"key": "org_2_access_token",
+			"value": ""
+		},
+		{
+			"key": "org_3_access_token",
+			"value": ""
+		},
+		{
+			"key": "org_1_holder",
+			"value": ""
+		},
+		{
+			"key": "org_1_tenant_url",
+			"value": ""
+		},
+		{
+			"key": "org_2_holder",
+			"value": ""
+		},
+		{
+			"key": "org_2_tenant_url",
+			"value": ""
+		},
+		{
+			"key": "org_3_holder",
+			"value": ""
+		},
+		{
+			"key": "org_3_tenant_url",
+			"value": ""
+		},
+		{
+			"key": "importers_proforma_invoice_vc",
+			"value": ""
+		},
+		{
+			"key": "org_3_domain",
+			"value": ""
+		},
+		{
+			"key": "org_3_challenge",
+			"value": ""
+		},
+		{
+			"key": "importers_proforma_invoice_presented_to_customs",
+			"value": ""
+		},
+		{
+			"key": "customs_first_workflow_instance_id",
+			"value": ""
+		},
+		{
+			"key": "freight_forwarders_hbol_vc",
+			"value": ""
+		},
+		{
+			"key": "freight_forwarders_house_bill_presented_to_customs",
+			"value": ""
+		},
+		{
+			"key": "customs_second_workflow_instance_id",
+			"value": ""
+		},
+		{
+			"key": "importers_commercial_invoice_vc",
+			"value": ""
+		},
+		{
+			"key": "org_2_domain",
+			"value": ""
+		},
+		{
+			"key": "org_2_challenge",
+			"value": ""
+		},
+		{
+			"key": "importers_presentation_of_ci_to_freight_forwarder",
+			"value": ""
+		},
+		{
+			"key": "freight_forwarders_presentation_of_ci_to_customs",
+			"value": ""
 		}
 	]
 }


### PR DESCRIPTION
I stored some variables to the environment in this collection. I think that has caused some failures when run in parallel actions alongside other collections. So this isolates the collection to only using collectionVariables. 

Also I've changed the request names to the common conventions which should make it look better in the report.   