### PR TITLE
fix: update OpenAPI yaml for DID resolution response

### DIFF
--- a/docs/openapi/schemas/DidResolutionResponse.yml
+++ b/docs/openapi/schemas/DidResolutionResponse.yml
@@ -4,6 +4,29 @@ required:
 properties:
   didDocument:
     type: object
+    required:
+      - alsoKnownAs
+      - service
+    properties:
+      alsoKnownAs:
+        type: array
+        minItems: 2
+        uniqueItems: true
+        items:
+          type: string
+      service:
+        type: array
+        minItems: 1
+        items:
+          type: object
+          required:
+            - type
+            - serviceEndpoint
+          properties:
+            type:
+              type: string
+            serviceEndpoint:
+              type: string
   didResolutionMetadata:
     type: object
   didDocumentMetadata:


### PR DESCRIPTION
Update the YAML for DID resolution response so that `alsoKnownAs` must be an array of strings with at least two elements, and service must be a non-empty array with objects that contain type and serviceEndpoint string properties. Note that it does not seem possible to require that one of the service elements contain a serviceEndpoint.type property with the value "TraceabilityAPI" while using OAS v3.0.0

FIXES: #118