### PR TITLE
feat: adding implied oauth exchange endpoint

### DIFF
--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -128,6 +128,7 @@ https://platform.example/organization/123/presentations/prove
 https://platform.example/organization/123/presentations/verify
 https://platform.example/organization/123/presentations/available
 https://platform.example/organization/123/presentations/submissions
+https://platform.example/organization/123/presentations
 ```
 
 These endpoints require the application to be authenticated:


### PR DESCRIPTION
I suppose this is how we expect to discover each others oauth presentation endpoints. 