### PR TITLE
Fix Presentation Exchange Collection

### DIFF
--- a/docs/tutorials/presentations-exchange/presentations-exchange.postman_collection.json
+++ b/docs/tutorials/presentations-exchange/presentations-exchange.postman_collection.json
@@ -351,7 +351,6 @@
 							"// pm.collectionVariables.get(\"credential_issuer_id\").",
 							"pm.test(\"`credential_issuer_id` persisted to collectionVariables\", function() {",
 							"    const { alsoKnownAs } = pm.response.json().didDocument;",
-							"    pm.collectionVariables.set(\"credential_issuer_id\", alsoKnownAs[1]);",
 							"});",
 							"",
 							"// The serviceEndpoint for the verifier must be persisted for later use",


### PR DESCRIPTION
The request for `Get Organization DIDs (Issuer)` sets the value for `credential_issuer_id` on [line 236](https://github.com/w3c-ccg/traceability-interop/blob/f274bdb7aeff5cef812352180b4227b910d1ecda/docs/tutorials/presentations-exchange/presentations-exchange.postman_collection.json#L236).

This value is then later overwritten by the `Get Organization DIDs (Verifier)`  call which overwrites the `credential_issuer_id` with the the verifier's `did:key`, which is what this PR addresses. 

### Showing the Error

```
→ Issue Credential
  POST {{BASE_API_URL}}/credentials/issue  
  400 Bad Request ★ 2s time ★ 1.65kB↑ 445B↓ size ★ 10↑ 8↓ headers ★ 0 cookies
  ┌ ↑ raw ★ 551B
  │ {
  │     "credential": {
  │         "@context": [
  │             "https://www.w3.org/2018/credentials/v1"
  │         ],
  │         "id": "urn:uuid:1721d654-d2af-490d-bf55-d8e20c3ff827",
  │         "type": [
  │             "VerifiableCredential"
  │         ],
  │         "issuer": "did:key:z6MkpJk229J6YzxZ6k621tLbDDK85ymG5uGeMfEuNmjf6ubu", <--- This is verifiers did:key
  │         "issuanceDate": "2010-01-01T19:23:24Z",
  │         "credentialSubject": {
  │             "id": "did:example:123"
  │         }
  │     },
  │     "options": {
  │         "type": "Ed25519Signature2018",
  │         "created": "2020-04-02T18:48:36Z"
  │     }
  │ }
  └ 
  ┌ ↓ application/json ★ text ★ json ★ utf8 ★ 159B
  │ {"message":"Please make sure that the issuer DID is controlled by your organization.","errors":["Your organization does not control the key for this issuer."]}
  └
  prepare   wait    dns-lookup   tcp-handshake   ssl-handshake   transfer-start   download   process   total 
  3ms       638µs   (cache)      (cache)         (cache)         2s               3ms        95µs      2s    

  ✓  `issuer_access_token` collection variable must be set
  ✓  `credential_issuer_id` collection variable must be set
  1. must return `201 Created` status
  ✓  `verifiable_credential` persisted to collectionVariables
  2⠄ AssertionFailure in test-script
```

### After PR Fix

Seems to work. 

```
┌─────────────────────────┬──────────────────────┬─────────────────────┐
│                         │             executed │              failed │
├─────────────────────────┼──────────────────────┼─────────────────────┤
│              iterations │                    1 │                   0 │
├─────────────────────────┼──────────────────────┼─────────────────────┤
│                requests │                    8 │                   0 │
├─────────────────────────┼──────────────────────┼─────────────────────┤
│            test-scripts │                   16 │                   0 │
├─────────────────────────┼──────────────────────┼─────────────────────┤
│      prerequest-scripts │                    9 │                   0 │
├─────────────────────────┼──────────────────────┼─────────────────────┤
│              assertions │                   52 │                   0 │
├─────────────────────────┴──────────────────────┴─────────────────────┤
│ total run duration: 10s                                              │
├──────────────────────────────────────────────────────────────────────┤
│ total data received: 5.52kB (approx)                                 │
├──────────────────────────────────────────────────────────────────────┤
│ average response time: 1190ms [min: 402ms, max: 2.9s, s.d.: 836ms]   │
├──────────────────────────────────────────────────────────────────────┤
│ average DNS lookup time: 500µs [min: 500µs, max: 500µs, s.d.: 0µs]   │
├──────────────────────────────────────────────────────────────────────┤
│ average first byte time: 1171ms [min: 287ms, max: 2.9s, s.d.: 850ms] │
└──────────────────────────────────────────────────────────────────────┘
✨. All Tests passing!!! (good job)
```
