### PR TITLE
Remove Merkle Proof Selective Disclosure

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -453,7 +453,6 @@
           exist for this particular feature:
           <ul>
             <li>BBS+</li>
-            <li>Merkle Tree Proofs</li>
           </ul>
         </p>
         <section class="normative">
@@ -474,35 +473,6 @@
               BBS+ Signature Scheme
             </a> specification is consolidating work towards an updated version of
             BBS+ signatures that aim to resolve prior issues.
-          </p>
-        </section>
-        <section class="normative">
-          <h2>Merkle Tree Proofs</h2>
-          <p>
-            <a href="https://computersciencewiki.org/index.php/Merkle_proof">Merkle Tree</a>
-            based proofs for selective disclosure attempt to resolve
-            concerns around requirements for pairing friendly curves leveraged in
-            BBS+ and other approaches to selective disclosure by not mandating the
-            hashing and signature suite mechanism so that those algorithms may be
-            selected to meet the needs of a particular operating envrionment.
-          </p>
-          <p>
-            At the current time, Merkle proofs are unsuitable for production use, but test implementations support both
-            <a href="https://w3c-ccg.github.io/Merkle-Disclosure-2021/">LD Signatures</a>
-            and <a href="https://w3c-ccg.github.io/Merkle-Disclosure-2021/jwp/">Json Web Proofs</a>
-          </p>
-          <p>
-            This approach should permit usage of Merkle Tree based methods for selective disclosure
-            with NIST approved cryptography, and should also faciliate cryptographic agility
-            with the introduction of
-            <a href="https://csrc.nist.gov/projects/post-quantum-cryptography">
-              Post Quantum Cryptography (PQC)
-            </a>.
-          </p>
-          <p>
-            Until there is more work done on both the specification, reference implementations, and
-            evaluation of Merkle Tree Proofs, they SHOULD NOT be used in production, but MAY be used
-            for evalutation of selective disclosure capabilities.
           </p>
         </section>
       </section>


### PR DESCRIPTION
There are no standard implementations.

Adding excessive "early stage experimental stuff" harms the usability of the profile and make its harder to understand.

If we are not intending to test it, we ought not to include it.

We are currently not intending to test either BBS+ or Merkle Disclosure Proofs.

I suggest we remove both until we have added support for them and agreed to test them.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/traceability-interop/pull/235.html" title="Last updated on May 19, 2022, 5:55 PM UTC (3a7c36f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/traceability-interop/235/60d5df4...3a7c36f.html" title="Last updated on May 19, 2022, 5:55 PM UTC (3a7c36f)">Diff</a>