### PR TITLE
fix: remove deprecated test for persisting unused value

### DIFF
--- a/docs/tutorials/presentations-exchange/presentations-exchange.postman_collection.json
+++ b/docs/tutorials/presentations-exchange/presentations-exchange.postman_collection.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "5ab1fa5e-f50d-4dcf-b2f9-fc64296f1de9",
+		"_postman_id": "8b877171-8d96-4bec-aefb-538d3e4cf0bb",
 		"name": "Presentations Exchange Tutorial",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "4338127"
 	},
 	"item": [
 		{
@@ -344,13 +345,6 @@
 							"    const entry = service.find((s) => s.type == \"TraceabilityAPI\");",
 							"    pm.expect(entry).to.be.an('object').that.is.not.empty;",
 							"    pm.expect(entry.serviceEndpoint).to.be.a('string').that.is.not.empty;",
-							"});",
-							"",
-							"// The value of didDocument.alsoKnownAs[1] is persisted as a Postman collection",
-							"// variable that can be accessed by other requests in the collection by calling",
-							"// pm.collectionVariables.get(\"credential_issuer_id\").",
-							"pm.test(\"`credential_issuer_id` persisted to collectionVariables\", function() {",
-							"    const { alsoKnownAs } = pm.response.json().didDocument;",
 							"});",
 							"",
 							"// The serviceEndpoint for the verifier must be persisted for later use",


### PR DESCRIPTION
Remove the now deprecated test that was persisting collection variable for credential_issuer_id.

FIXES: #234