### PR TITLE
Update Collections to Use API Token

### DIFF
--- a/docs/tutorials/presentations-exchange-oauth/presentations-exchange-oauth.json
+++ b/docs/tutorials/presentations-exchange-oauth/presentations-exchange-oauth.json
@@ -106,7 +106,14 @@
 			},
 			"request": {
 				"auth": {
-					"type": "noauth"
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{verifier_access_token}}",
+							"type": "string"
+						}
+					]
 				},
 				"method": "GET",
 				"header": [

--- a/docs/tutorials/presentations-verify/presentations-verify.postman_collection.json
+++ b/docs/tutorials/presentations-verify/presentations-verify.postman_collection.json
@@ -288,7 +288,14 @@
 			},
 			"request": {
 				"auth": {
-					"type": "noauth"
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{issuer_access_token}}",
+							"type": "string"
+						}
+					]
 				},
 				"method": "GET",
 				"header": [


### PR DESCRIPTION
We recently updated our `GET: /identifiers/:did` end-point to require a bearer token. As a result, these tests need to be updated.