### PR TITLE
fix: use correct bearer token for verifier did resolution

### DIFF
--- a/docs/tutorials/presentations-verify/presentations-verify.postman_collection.json
+++ b/docs/tutorials/presentations-verify/presentations-verify.postman_collection.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "c50743d4-76d4-4e3c-8256-ba0c5125492e",
+		"_postman_id": "ed4b33c9-1d72-44ad-8d60-66332ebdcedd",
 		"name": "Presentations Verify Tutorial",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "4338127"
 	},
 	"item": [
 		{
@@ -292,7 +293,7 @@
 					"bearer": [
 						{
 							"key": "token",
-							"value": "{{issuer_access_token}}",
+							"value": "{{verifier_access_token}}",
 							"type": "string"
 						}
 					]


### PR DESCRIPTION
PR #260 updated the "Get Organization DIDs (Verifier)" request to use bearer auth, but used the `{{issuer_access_token}}` instead of the `{{verifier_access_token}}`.

This PR updates the request to use the proper token.