### PR TITLE
feat: add specific error response messages to spec

### DIFF
--- a/docs/openapi/responses/BadRequest.yml
+++ b/docs/openapi/responses/BadRequest.yml
@@ -2,4 +2,10 @@ description: Bad Request
 content:
   application/json:
     schema:
-      $ref: '../schemas/Error.yml'
+      allOf:
+        - $ref: '../schemas/Error.yml'
+        - type: object
+          properties:
+            message:
+              type: string
+              enum: ["Bad Request: Your request body not conform to the required schema"]

--- a/docs/openapi/responses/BadRequest.yml
+++ b/docs/openapi/responses/BadRequest.yml
@@ -9,4 +9,4 @@ content:
             code:
               enum: [400]
             message:
-              enum: ["Bad Request: Your request body not conform to the required schema"]
+              enum: ["Bad Request: Your request body does not conform to the required schema"]

--- a/docs/openapi/responses/BadRequest.yml
+++ b/docs/openapi/responses/BadRequest.yml
@@ -6,6 +6,7 @@ content:
         - $ref: '../schemas/Error.yml'
         - type: object
           properties:
+            code:
+              enum: [400]
             message:
-              type: string
               enum: ["Bad Request: Your request body not conform to the required schema"]

--- a/docs/openapi/responses/Unauthenticated.yml
+++ b/docs/openapi/responses/Unauthenticated.yml
@@ -6,6 +6,7 @@ content:
         - $ref: '../schemas/Error.yml'
         - type: object
           properties:
+            code:
+              enum: [401]
             message:
-              type: string
               enum: ["Unauthorized: This endpoint requires an OAuth2 bearer token"]

--- a/docs/openapi/responses/Unauthenticated.yml
+++ b/docs/openapi/responses/Unauthenticated.yml
@@ -1,5 +1,11 @@
-description: Not authenticated, access token required
+description: Unauthorized
 content:
   application/json:
     schema:
-      $ref: '../schemas/Error.yml'
+      allOf:
+        - $ref: '../schemas/Error.yml'
+        - type: object
+          properties:
+            message:
+              type: string
+              enum: ["Unauthorized: This endpoint requires an OAuth2 bearer token"]

--- a/docs/openapi/responses/Unauthorized.yml
+++ b/docs/openapi/responses/Unauthorized.yml
@@ -1,5 +1,11 @@
-description: Access token does not have the required scope
+description: Forbidden
 content:
   application/json:
     schema:
-      $ref: '../schemas/Error.yml'
+      allOf:
+        - $ref: '../schemas/Error.yml'
+        - type: object
+          properties:
+            message:
+              type: string
+              enum: ["Forbidden: OAuth2 bearer token does not have the required scope"]

--- a/docs/openapi/responses/Unauthorized.yml
+++ b/docs/openapi/responses/Unauthorized.yml
@@ -6,6 +6,7 @@ content:
         - $ref: '../schemas/Error.yml'
         - type: object
           properties:
+            code:
+              enum: [403]
             message:
-              type: string
               enum: ["Forbidden: OAuth2 bearer token does not have the required scope"]


### PR DESCRIPTION
Currently, the [response schema for errors](https://github.com/w3c-ccg/traceability-interop/blob/main/docs/openapi/schemas/Error.yml) includes an integer `code`, a string `message`, and an object `details`.

This PR adds support for defining specific values for `code` and `message` values in the OpenAPI spec, and leaves the `details` object up to the implementor.

REF: #41