### PR TITLE
Schedule conformance report suite

### DIFF
--- a/.github/workflows/conformance-run.yml
+++ b/.github/workflows/conformance-run.yml
@@ -2,9 +2,9 @@ name: Conformance Testing
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - 'tests/**'
+  schedule:
+    # Every day at midnight
+    - cron: '0 0 * * *'
 
 jobs:
   conformance-suite:
@@ -49,3 +49,28 @@ jobs:
           --reporter-htmlextra-skipSensitiveData \
           --reporter-htmlextra-export "newman/${{format('{0}-{1}-{2}.html', github.run_id, github.job, matrix.name)}}" \
           --reporter-json-export "newman/${{format('{0}-{1}-{2}.json', github.run_id, github.job, matrix.name)}}"
+
+      # Build report index
+      - name: Build JSON Index
+        run: npm run report:prepare
+
+      # Set up Python 3.x
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+          cache: pip
+      - run: pip install -r ./reporting/requirements.txt
+
+        # Build interactive report
+      - name: Build Interactive Report
+        working-directory: ./reporting
+        run: ./reporter.py --mode ci
+
+      # Publish reports subfolder to GitHub Pages
+      - name: Publish Reports
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/reports
+          destination_dir: reports/conformance

--- a/.github/workflows/conformance-run.yml
+++ b/.github/workflows/conformance-run.yml
@@ -7,10 +7,15 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  conformance-suite:
-    name: Conformance Suite
+
+  # conformance-run works through a matrix of actors and runs the conformance
+  # test suite for each of them. Results are stored in a `reports` artifact for
+  # later compilation and publishing.
+  conformance-run:
+    name: Run Conformance Suite
     runs-on: ubuntu-latest
     strategy:
+      # Job must not stop iterating through matrix on failure
       fail-fast: false
       matrix:
         include:
@@ -50,9 +55,42 @@ jobs:
           --reporter-htmlextra-export "newman/${{format('{0}-{1}-{2}.html', github.run_id, github.job, matrix.name)}}" \
           --reporter-json-export "newman/${{format('{0}-{1}-{2}.json', github.run_id, github.job, matrix.name)}}"
 
-      # Build report index
-      - name: Build JSON Index
+      # Sanitize newman output and write all reports to the `./docs/reports`
+      # folder for publishing. Note that this rebuilds and overwrites the
+      # `index.json` file with each matrix iteration (desired behavior).
+      - name: Sanitize Newman Output
+        if: always() # Run even when postman tests fail
         run: npm run report:prepare
+
+      # Sanitized reports are needed by subsequent jobs
+      - uses: actions/upload-artifact@v3
+        if: always() # Run even when postman tests fail
+        with:
+          name: reports
+          path: docs/reports/
+
+  # conformance-compile compiles the sanitized raw report output into an
+  # interactive HTML conformance report suitable for publishing.
+  conformance-compile:
+    name: Compile Reports
+    runs-on: ubuntu-latest
+
+    # Run even when postman tests fail
+    if: always()
+
+    # Wait for jobs which generate reporting input.
+    needs:
+      - conformance-run
+
+    steps:
+      # Check out repo
+      - uses: actions/checkout@v3
+
+      # Download 'reports' artifact
+      - uses: actions/download-artifact@v3
+        with:
+          name: reports
+          path: docs/reports/
 
       # Set up Python 3.x
       - name: Set up Python 3.x
@@ -62,13 +100,47 @@ jobs:
           cache: pip
       - run: pip install -r ./reporting/requirements.txt
 
-        # Build interactive report
-      - name: Build Interactive Report
+      # Compile interactive report
+      - name: Build Conformance Report
         working-directory: ./reporting
         run: ./reporter.py --mode ci
 
+      # Compiled report must be added to artifact
+      - uses: actions/upload-artifact@v3
+        with:
+          name: reports
+          path: docs/reports/
+
+  # conformance-publish publishes sanitized raw and interactive HTML reports to
+  # the `reports/conformance` directory in GitHub pages. This job is restricted
+  # to commits on the `main` branch to prevent feature branches from overwriting
+  # production reports.
+  conformance-publish:
+    name: Publish Report
+    runs-on: ubuntu-latest
+
+    # Publishing must only happen when triggered on the 'main' branch to prevent
+    # tests on other branches from polluting the published reports. Note that
+    # `always()`` is a special flag that is REQUIRED in order to get this job to
+    # run if jobs listed in the `needs:` section fail.
+    if: github.ref == 'refs/heads/main' && always()
+
+    # Report must be compiled before publishing
+    needs:
+      - conformance-compile
+
+    steps:
+      # Check out repo
+      - uses: actions/checkout@v3
+
+      # Download 'reports' artifact
+      - uses: actions/download-artifact@v3
+        with:
+          name: reports
+          path: docs/reports/
+
       # Publish reports subfolder to GitHub Pages
-      - name: Publish Reports
+      - name: Publish Conformance Report
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/interoperability-report.yml
+++ b/.github/workflows/interoperability-report.yml
@@ -692,4 +692,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/reports
-          destination_dir: reports
+          destination_dir: reports/interoperability

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 
 ## Traceability Interoperability
 
-- [Test Suite](https://w3id.org/traceability/interoperability/reports)
+- [Conformance Test Suite](https://w3id.org/traceability/interoperability/reports/conformance)
+- [Interoperability Test Suite](https://w3id.org/traceability/interoperability/reports/interoperability)
 - [Getting Started](https://github.com/w3c-ccg/traceability-interop/tree/main/reporting)
 - [Test Report Archive](https://w3id.org/traceability/interoperability/reports/index.json)
 


### PR DESCRIPTION
Add nightly scheduled conformance report suite. The resulting published report will contain MANY tests, and is currently being published separately from the interoperability report.

FIX #265