### PR TITLE
Add onboard workflow to main

### DIFF
--- a/.github/workflows/test-suite-registration.yml
+++ b/.github/workflows/test-suite-registration.yml
@@ -1,0 +1,38 @@
+# Prerequisites:
+# - Create a secret with your PAT token. Permissions needed: repo (all) and read:org
+# - Create the HELLO_WORLD secret in your environment with some dummy initial value
+#
+# Notes:
+# - You can tell that it works because it masks the secret_body in the echo secret step after it creates the secret 😄
+# - If you don't want to have to pass --repo to gh secret set, then put the actions/checkout@v2 step before the gh secret set step
+
+name: gh-set-secret
+
+on:
+  workflow_dispatch:
+
+env:
+  secret_name: HELLO_WORLD
+  secret_body: "Hello World!"
+
+jobs:
+  gh-set-secret:
+    runs-on: ubuntu-latest
+    steps:
+      - name: gh secret set env
+        shell: bash
+        run: |
+          gh auth status -t
+        # gh secret set "$secret_name" --body "$secret_body" --repo github.repository
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  gh-test-secret:
+    needs: [gh-set-secret]
+    runs-on: ubuntu-latest
+    env:
+      secret: ${{ secrets.HELLO_WORLD }}
+    steps:
+      - name: echo secret
+        shell: bash
+        run: |
+          echo "Secret: $secret"

--- a/.github/workflows/test-suite-registration.yml
+++ b/.github/workflows/test-suite-registration.yml
@@ -36,3 +36,6 @@ jobs:
         shell: bash
         run: |
           echo "Secret: $secret"
+
+# gh gpg-key
+# https://cli.github.com/manual/gh_gpg-key

--- a/README.md
+++ b/README.md
@@ -83,18 +83,17 @@ This implementation will cover all required AND optional APIs and will be used t
 
 ## Postman Interoperability Test Suite
 
-In order to ensure interoperability tests are conducted in a manner consistent with production environments, we maintain a set of postman collections and client credential configuration located in the [tutorials](./docs/tutorials/) section of the docs.  These tests are executed in github actons, on demand by implementers, as well as being run on a nightly scheduled basis.
+In order to ensure interoperability tests are conducted in a manner consistent with production environments, we maintain a set of Postman collections and client credential configuration located in the [tutorials](./docs/tutorials/) section of the docs.  These tests are executed via GitHub actions, on demand by implementers, as well as being run on a nightly scheduled basis.
 
-This approach allows us to test implementations in production with the appropriate security and authorizaton policies in place.
+This approach allows us to test implementations in production with the appropriate security and authorization policies in place.
 
-
-If you would like to register an implementation with to the test suite, please contact one of the editors of the specification as listed here:
+If you would like to register an implementation to be tested against the test suite, please contact one of the editors of the specification as listed here:
 
 - [Orie Steele](mailto:orie@transmute.industries?subject=[GitHub]%20Traceability%20Interop%20Test%20Registration)
 - [Michael Prorock](mailto:mprorock@mesur.io?subject=[GitHub]%20Traceability%20Interop%20Test%20Registration)
 - [Mahmoud Alkhraishi](mailto:mahmoud@mavennet.com?subject=[GitHub]%20Traceability%20Interop%20Test%20Registration)
 
-Test Suite Registration is required for participation in up coming Technical Demonstrations with various government and non-government entities related to trade and import/export data exchange.
+Test suite registration is required for participation in upcoming technical demonstrations with various government and non-government entities related to trade and import/export data exchange.
 
 ## Development
 


### PR DESCRIPTION
New workflows can't be tested if they are not present on `main`.

REF: #261 