### PR TITLE
docs: update hosting instructions, add AGENDA.md

### DIFF
--- a/AGENDA.md
+++ b/AGENDA.md
@@ -1,0 +1,41 @@
+# Open API for Interoperable Traceability
+
+The agenda may be updated periodically if a special topic is under discussion, or a guest speaker is identified, etc.  In the event that the agenda is updated, the updated agenda will be distributed to the W3C CCG mailing list.
+
+1. IP Note, Agenda Review, Scribe Selection (5 minutes)
+
+    - Agenda Review (2 minutes)
+
+    - IP Note: (1 minute)
+
+      > Anyone can participate in these calls. However, all substantive contributors to any CCG Work Items must be members of the CCG with full IPR agreements signed. https://www.w3.org/community/credentials/join
+
+        * Ensure you have a W3 account: https://www.w3.org/accounts/request
+
+        * W3C COMMUNITY CONTRIBUTOR LICENSE AGREEMENT (CLA): https://www.w3.org/community/about/agreements/cla/
+
+    -  Call Notes (1 minute)
+
+        - These minutes and an audio recording of everything said on this call are archived at https://w3c-ccg.github.io/meetings/
+
+        - We use Jitsi text chat to queue speakers during the call as well as to take minutes.
+
+        - All attendees should type “present+” to get your name on the attendee list in the transcript.
+
+        - In IRC type “q+” to add yourself to the queue, with an optional reminder, e.g., “q+ to mention something”. The “to” is required.
+
+        - If you’re not on chat, simply ask to be put on the queue.
+
+        - Please be brief so the rest of the queue get a chance to chime in. You can always q+ again.
+
+        - NOTE: This meeting is held by voice, not by text. Off-topic text comments are subject to deletion from the record. We work hard to manage a single thread of conversation so everyone can participate and be heard. Please respect the group process by joining the queue when you have something to contribute.
+
+    - Scribe Selection (2 minutes) - We need a volunteer to scribe.
+
+2. GitHub Issue & PR review
+
+3. GitHub Issue & PR review (Other related repos - if required or referenced)
+
+4. Proposals to Address Challenges
+
+5. Next Steps

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ channel automatically.
 
       For this portion of the meeting, address PRs in the focus repository first, followed by PRs in the other repository.
 
-        - Publish link to sorted PRs in chat box
+        - Publish link to sorted PRs in chat box ([trace-interop](https://github.com/w3c-ccg/traceability-interop/pulls?q=is%3Apr+is%3Aopen+sort%3Acreated-asc), [trace-vocab](https://github.com/w3c-ccg/traceability-vocab/pulls?q=is%3Apr+is%3Aopen+sort%3Acreated-asc))
 
         - Publish link to each PR being discussed in chat box
 
@@ -70,7 +70,7 @@ channel automatically.
 
       For this portion of the meeting, address issues in the focus repository first, followed by issues in the other repository.
 
-        - Publish link to sorted issues in chat box
+        - Publish link to sorted issues in chat box ([trace-interop](https://github.com/w3c-ccg/traceability-interop/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-asc), [trace-vocab](https://github.com/w3c-ccg/traceability-vocab/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-asc))
 
         - Publish link to each issue being discussed in chat box
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,47 @@ channel automatically.
 
 1. Make sure to select "Start Recording" at the beginning of the call and "Stop
    Recording" when you're done.
-2. Make sure to kick everyone out of the room when the meeting is done.
-3. Once the last person leaves, everything else is automated (publishing raw IRC
-   log, audio, and video). If you want to clean up the minutes, it takes about
-   5-10 minutes to clean up the transcription and publish it.
+
+1. Select "Start Recording" to start audio recording
+
+1. Post the agenda link in the meeting chat box
+
+   `Agenda: https://github.com/w3c-ccg/traceability-interop/AGENDA.md`
+1. Address IP note, agenda review, and scribe selection topic
+
+    - Note the topic in the chat box
+
+      `Topic: IP Note, Agenda Review, Scribe Selection`
+    - Announce the agenda for the meeting. Meetings alternate between focus on the trace-interop and trace-vocab repositories.
+    - Read the standard IP note
+
+      > Anyone can participate in these calls. However, all substantive contributors to any CCG Work Items must be members of the CCG with full IPR agreements signed. Information about and links to the required license agreements can be found in the meeting agenda.
+
+1. Move on to GitHub Issue & PR review
+
+    - Note the next topic in the chat box
+
+      `Topic: GitHub Issue & PR review`
+
+    - Review pull requests in order (oldest first)
+
+      For this portion of the meeting, address PRs in the focus repository first, followed by PRs in the other repository.
+
+        - Publish link to sorted PRs in chat box
+
+        - Publish link to each PR being discussed in chat box
+
+    - Review issues in order (least recently updated first)
+
+      For this portion of the meeting, address issues in the focus repository first, followed by issues in the other repository.
+
+        - Publish link to sorted issues in chat box
+
+        - Publish link to each issue being discussed in chat box
+
+1. Make sure to kick everyone out of the room when the meeting is done.
+
+1. Retrieve and publish meeting minutes
 
 #### Retrieving Minutes
 


### PR DESCRIPTION
Add ADENDA.md to repository so that it can be linked during meetings, and update README.md to include more detailed hosting instructions.