### PR TITLE
Optional security for public credentials

### DIFF
--- a/docs/openapi/resources/credential.yml
+++ b/docs/openapi/resources/credential.yml
@@ -6,6 +6,7 @@ get:
   tags:
     - Credentials
   security:
+    - {}
     - OAuth2:
         - 'read:credentials'
   parameters:


### PR DESCRIPTION
Ref https://github.com/w3c-ccg/traceability-interop/issues/247

I'm fairly sure this is the right syntax for optional security. The swagger editor accepts it too: 

![image](https://user-images.githubusercontent.com/34443212/178993314-853c653b-5949-4d5b-b738-fbcbd199dae5.png)
