### PR TITLE
fix: rename responseSchema201

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -2402,7 +2402,7 @@
 											"});",
 											"",
 											"pm.test(\"response validates against schema\", function() {",
-											" const schemaString = pm.collectionVariables.get(\"responseSchema201\");",
+											" const schemaString = pm.collectionVariables.get(\"responseSchema201CredentialsIssue\");",
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 											"});",
 											""
@@ -2466,7 +2466,7 @@
 											"});",
 											"",
 											"pm.test(\"response validates against schema\", function() {",
-											" const schemaString = pm.collectionVariables.get(\"responseSchema201\");",
+											" const schemaString = pm.collectionVariables.get(\"responseSchema201CredentialsIssue\");",
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 											"});",
 											""
@@ -2533,7 +2533,7 @@
 											"});",
 											"",
 											"pm.test(\"response validates against schema\", function() {",
-											" const schemaString = pm.collectionVariables.get(\"responseSchema201\");",
+											" const schemaString = pm.collectionVariables.get(\"responseSchema201CredentialsIssue\");",
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 											"});",
 											""
@@ -2600,7 +2600,7 @@
 											"});",
 											"",
 											"pm.test(\"response validates against schema\", function() {",
-											" const schemaString = pm.collectionVariables.get(\"responseSchema201\");",
+											" const schemaString = pm.collectionVariables.get(\"responseSchema201CredentialsIssue\");",
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 											"});",
 											""
@@ -2667,7 +2667,7 @@
 											"});",
 											"",
 											"pm.test(\"response validates against schema\", function() {",
-											" const schemaString = pm.collectionVariables.get(\"responseSchema201\");",
+											" const schemaString = pm.collectionVariables.get(\"responseSchema201CredentialsIssue\");",
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 											"});",
 											""
@@ -2734,7 +2734,7 @@
 											"});",
 											"",
 											"pm.test(\"response validates against schema\", function() {",
-											" const schemaString = pm.collectionVariables.get(\"responseSchema201\");",
+											" const schemaString = pm.collectionVariables.get(\"responseSchema201CredentialsIssue\");",
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 											"});",
 											""
@@ -2801,7 +2801,7 @@
 											"});",
 											"",
 											"pm.test(\"response validates against schema\", function() {",
-											" const schemaString = pm.collectionVariables.get(\"responseSchema201\");",
+											" const schemaString = pm.collectionVariables.get(\"responseSchema201CredentialsIssue\");",
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 											"});",
 											""
@@ -2868,7 +2868,7 @@
 											"});",
 											"",
 											"pm.test(\"response validates against schema\", function() {",
-											" const schemaString = pm.collectionVariables.get(\"responseSchema201\");",
+											" const schemaString = pm.collectionVariables.get(\"responseSchema201CredentialsIssue\");",
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 											"});",
 											""
@@ -2935,7 +2935,7 @@
 											"});",
 											"",
 											"pm.test(\"response validates against schema\", function() {",
-											" const schemaString = pm.collectionVariables.get(\"responseSchema201\");",
+											" const schemaString = pm.collectionVariables.get(\"responseSchema201CredentialsIssue\");",
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 											"});",
 											""
@@ -3327,7 +3327,7 @@
 	],
 	"variable": [
 		{
-			"key": "responseSchema201",
+			"key": "responseSchema201CredentialsIssue",
 			"value": "{\"title\":\"Serialized Verifiable Credential\",\"oneOf\":[{\"title\":\"Verifiable Credential\",\"type\":\"object\",\"allOf\":[{\"type\":\"object\",\"required\":[\"@context\",\"type\",\"issuer\",\"issuanceDate\",\"credentialSubject\"],\"properties\":{\"@context\":{\"description\":\"This JSON-LD Context defining all terms in the Credential.\",\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"id\":{\"description\":\"The IRI identifying the Credential\",\"type\":\"string\"},\"type\":{\"description\":\"The Type of the Credential\",\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"issuer\":{\"description\":\"This value MUST match the assertionMethod used to create the Verifiable Credential.\",\"oneOf\":[{\"type\":\"string\"},{\"type\":\"object\",\"required\":[\"id\"],\"properties\":{\"id\":{\"description\":\"The IRI identifying the Issuer\",\"type\":\"string\"}}}]},\"issuanceDate\":{\"description\":\"This value MUST be an XML Date Time String\",\"type\":\"string\"},\"credentialSubject\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"object\",\"properties\":{\"id\":{\"description\":\"The IRI identifying the Subject\",\"type\":\"string\"}}}]}},\"example\":{\"@context\":[\"https://www.w3.org/2018/credentials/v1\"],\"id\":\"urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded\",\"type\":[\"VerifiableCredential\"],\"issuer\":\"did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn\",\"issuanceDate\":\"2010-01-01T19:23:24Z\",\"credentialSubject\":\"did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn\"}},{\"type\":\"object\",\"properties\":{\"proof\":{\"title\":\"Credential Linked Data Proof\",\"allOf\":[{\"title\":\"Linked Data Proof\",\"type\":\"object\",\"description\":\"A JSON-LD Linked Data proof.\",\"properties\":{\"type\":{\"type\":\"string\",\"description\":\"Linked Data Signature Suite used to produce proof.\",\"enum\":[\"JsonWebSignature2020\"]},\"created\":{\"type\":\"string\",\"description\":\"Date the proof was created.\"},\"verificationMethod\":{\"type\":\"string\",\"description\":\"Verification Method used to verify proof.\"},\"jws\":{\"type\":\"string\",\"description\":\"Detached JSON Web Signature\"}},\"example\":{\"type\":\"JsonWebSignature2020\",\"created\":\"2020-04-02T18:28:08Z\",\"verificationMethod\":\"did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN\",\"proofPurpose\":\"assertionMethod\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YtqjEYnFENT7fNW-COD0HAACxeuQxPKAmp4nIl8jYAu__6IH2FpSxv81w-l5PvE1og50tS9tH8WyXMlXyo45CA\"}},{\"type\":\"object\",\"properties\":{\"proofPurpose\":{\"type\":\"string\",\"description\":\"Credentials rely on assertionMethod proof purpose.\",\"enum\":[\"assertionMethod\"]}}}]}}}],\"example\":{\"@context\":[\"https://www.w3.org/2018/credentials/v1\"],\"id\":\"urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded\",\"type\":[\"VerifiableCredential\"],\"issuer\":\"did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn\",\"issuanceDate\":\"2010-01-01T19:23:24Z\",\"credentialSubject\":\"did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn\",\"proof\":{\"type\":\"Ed25519Signature2018\",\"created\":\"2021-10-30T19:16:30Z\",\"verificationMethod\":\"did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn\",\"proofPurpose\":\"assertionMethod\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..puetBYS3pkYlYzAecBiT-WkigYAlVbslrz9wPFnk9JW4AwjrpJvcsSdZJPhZtNy_myMJUNzC_QaYyw3ni1V0BA\"}}},{\"title\":\"VC JWT\",\"type\":\"string\",\"example\":\"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa3RpU3pxRjlrcXdkVThWa2RCS3g1NkVZelhmcGduTlBVQUd6bnBpY05pV2ZuI3o2TWt0aVN6cUY5a3F3ZFU4VmtkQkt4NTZFWXpYZnBnbk5QVUFHem5waWNOaVdmbiJ9.eyJpc3MiOiJkaWQ6a2V5Ono2TWt0aVN6cUY5a3F3ZFU4VmtkQkt4NTZFWXpYZnBnbk5QVUFHem5waWNOaVdmbiIsInN1YiI6ImRpZDprZXk6ejZNa3RpU3pxRjlrcXdkVThWa2RCS3g1NkVZelhmcGduTlBVQUd6bnBpY05pV2ZuIiwidmMiOnsiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL3czaWQub3JnL3NlY3VyaXR5L3N1aXRlcy9qd3MtMjAyMC92MSJdLCJpZCI6InVybjp1dWlkOjA3YWE5NjllLWI0MGQtNGMxYi1hYjQ2LWRlZDI1MjAwM2RlZCIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiZGlkOmtleTp6Nk1rdGlTenFGOWtxd2RVOFZrZEJLeDU2RVl6WGZwZ25OUFVBR3pucGljTmlXZm4iLCJpc3N1YW5jZURhdGUiOiIyMDEwLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTdWJqZWN0IjoiZGlkOmtleTp6Nk1rdGlTenFGOWtxd2RVOFZrZEJLeDU2RVl6WGZwZ25OUFVBR3pucGljTmlXZm4ifSwianRpIjoidXJuOnV1aWQ6MDdhYTk2OWUtYjQwZC00YzFiLWFiNDYtZGVkMjUyMDAzZGVkIiwibmJmIjoxMjYyMzczODA0fQ.ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbUkyTkNJNlptRnNjMlVzSW1OeWFYUWlPbHNpWWpZMElsMTkuLlBUZ1N5UndTRmdRRmZRQXJRSkVfUm43c3cyNzJRZnhlTUZjYk16R05KZDRKVGtWS3d4a2p1UzRXQV9xTGdhM2NGYzRKd0JILXJPMk5haTFfRExsWEF3\"}],\"example\":{\"@context\":[\"https://www.w3.org/2018/credentials/v1\"],\"id\":\"urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded\",\"type\":[\"VerifiableCredential\"],\"issuer\":\"did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn\",\"issuanceDate\":\"2010-01-01T19:23:24Z\",\"credentialSubject\":\"did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn\",\"proof\":{\"type\":\"Ed25519Signature2018\",\"created\":\"2021-10-30T19:16:30Z\",\"verificationMethod\":\"did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn\",\"proofPurpose\":\"assertionMethod\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..puetBYS3pkYlYzAecBiT-WkigYAlVbslrz9wPFnk9JW4AwjrpJvcsSdZJPhZtNy_myMJUNzC_QaYyw3ni1V0BA\"}}}",
 			"type": "string"
 		},

--- a/tests/update_conformance_schemas.sh
+++ b/tests/update_conformance_schemas.sh
@@ -48,7 +48,7 @@ update_postman \
 # Credentials - Issue [201]
 update_postman \
 "conformance_suite.postman_collection.json" \
-  "responseSchema201" \
+  "responseSchema201CredentialsIssue" \
   "$(get_schema '.paths["/credentials/issue"].post.responses["201"].content["application/json"].schema')"
 
 # Credentials - Issue [400]


### PR DESCRIPTION
Current name of variable used to store JSON schema for validation on 201 responses for the /credentials/issue endpoint is `responseSchema201`. Preventing future clashes with other 201 responses that require validation, e.g., `/presentations/prove`, by renaming to `responseSchema201CredentialsIssue`.