### PR TITLE
style: namespace /credentials/issue conformance requests

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -16,7 +16,7 @@
 							"name": "Bad Request",
 							"item": [
 								{
-									"name": "credential:missing",
+									"name": "credentials_issue:credential:missing",
 									"event": [
 										{
 											"listen": "test",
@@ -84,7 +84,7 @@
 									"response": []
 								},
 								{
-									"name": "credential.@context:missing",
+									"name": "credentials_issue:credential.@context:missing",
 									"event": [
 										{
 											"listen": "test",
@@ -152,7 +152,7 @@
 									"response": []
 								},
 								{
-									"name": "credential.@context:wrong_type",
+									"name": "credentials_issue:credential.@context:wrong_type",
 									"event": [
 										{
 											"listen": "test",
@@ -220,7 +220,7 @@
 									"response": []
 								},
 								{
-									"name": "credential.@context.members:wrong_type",
+									"name": "credentials_issue:credential.@context.members:wrong_type",
 									"event": [
 										{
 											"listen": "test",
@@ -288,7 +288,7 @@
 									"response": []
 								},
 								{
-									"name": "credential.id:wrong_type",
+									"name": "credentials_issue:credential.id:wrong_type",
 									"event": [
 										{
 											"listen": "test",
@@ -356,7 +356,7 @@
 									"response": []
 								},
 								{
-									"name": "credential.type:missing",
+									"name": "credentials_issue:credential.type:missing",
 									"event": [
 										{
 											"listen": "test",
@@ -424,7 +424,7 @@
 									"response": []
 								},
 								{
-									"name": "credential.type:wrong_type",
+									"name": "credentials_issue:credential.type:wrong_type",
 									"event": [
 										{
 											"listen": "test",
@@ -492,7 +492,7 @@
 									"response": []
 								},
 								{
-									"name": "credential.type.members:wrong_type",
+									"name": "credentials_issue:credential.type.members:wrong_type",
 									"event": [
 										{
 											"listen": "test",
@@ -560,7 +560,7 @@
 									"response": []
 								},
 								{
-									"name": "credential.issuer:missing",
+									"name": "credentials_issue:credential.issuer:missing",
 									"event": [
 										{
 											"listen": "test",
@@ -628,7 +628,7 @@
 									"response": []
 								},
 								{
-									"name": "credential.issuer:wrong_type",
+									"name": "credentials_issue:credential.issuer:wrong_type",
 									"event": [
 										{
 											"listen": "test",
@@ -696,7 +696,7 @@
 									"response": []
 								},
 								{
-									"name": "credential.issuer.id:wrong_type",
+									"name": "credentials_issue:credential.issuer.id:wrong_type",
 									"event": [
 										{
 											"listen": "test",
@@ -765,7 +765,7 @@
 									"response": []
 								},
 								{
-									"name": "credential.issuanceDate.missing",
+									"name": "credentials_issue:credential.issuanceDate.missing",
 									"event": [
 										{
 											"listen": "test",
@@ -833,7 +833,7 @@
 									"response": []
 								},
 								{
-									"name": "credential.issuanceDate:wrong_type",
+									"name": "credentials_issue:credential.issuanceDate:wrong_type",
 									"event": [
 										{
 											"listen": "test",
@@ -901,7 +901,7 @@
 									"response": []
 								},
 								{
-									"name": "credential.issuanceDate:invalid_value",
+									"name": "credentials_issue:credential.issuanceDate:invalid_value",
 									"event": [
 										{
 											"listen": "test",
@@ -969,7 +969,7 @@
 									"response": []
 								},
 								{
-									"name": "credential.credentialSubject:missing",
+									"name": "credentials_issue:credential.credentialSubject:missing",
 									"event": [
 										{
 											"listen": "test",
@@ -1037,7 +1037,7 @@
 									"response": []
 								},
 								{
-									"name": "credential.credentialSubject:wrong_type",
+									"name": "credentials_issue:credential.credentialSubject:wrong_type",
 									"event": [
 										{
 											"listen": "test",
@@ -1105,7 +1105,7 @@
 									"response": []
 								},
 								{
-									"name": "credential.credentialSubject.id:wrong_type",
+									"name": "credentials_issue:credential.credentialSubject.id:wrong_type",
 									"event": [
 										{
 											"listen": "test",
@@ -1174,7 +1174,7 @@
 									"response": []
 								},
 								{
-									"name": "options:missing",
+									"name": "credentials_issue:options:missing",
 									"event": [
 										{
 											"listen": "test",
@@ -1242,7 +1242,7 @@
 									"response": []
 								},
 								{
-									"name": "options:wrong_type",
+									"name": "credentials_issue:options:wrong_type",
 									"event": [
 										{
 											"listen": "test",
@@ -1310,7 +1310,7 @@
 									"response": []
 								},
 								{
-									"name": "options.type:missing",
+									"name": "credentials_issue:options.type:missing",
 									"event": [
 										{
 											"listen": "test",
@@ -1378,7 +1378,7 @@
 									"response": []
 								},
 								{
-									"name": "options.type:wrong_type",
+									"name": "credentials_issue:options.type:wrong_type",
 									"event": [
 										{
 											"listen": "test",
@@ -1446,7 +1446,7 @@
 									"response": []
 								},
 								{
-									"name": "options.type:invalid_value",
+									"name": "credentials_issue:options.type:invalid_value",
 									"event": [
 										{
 											"listen": "test",
@@ -1514,7 +1514,7 @@
 									"response": []
 								},
 								{
-									"name": "options.created:wrong_type",
+									"name": "credentials_issue:options.created:wrong_type",
 									"event": [
 										{
 											"listen": "test",
@@ -1592,7 +1592,7 @@
 									"response": []
 								},
 								{
-									"name": "options.credentialStatus:wrong_type",
+									"name": "credentials_issue:options.credentialStatus:wrong_type",
 									"event": [
 										{
 											"listen": "test",
@@ -1660,7 +1660,7 @@
 									"response": []
 								},
 								{
-									"name": "options.credentialStatus.type:wrong_type",
+									"name": "credentials_issue:options.credentialStatus.type:wrong_type",
 									"event": [
 										{
 											"listen": "test",
@@ -1728,7 +1728,7 @@
 									"response": []
 								},
 								{
-									"name": "options.credentialStatus.type:invalid_value",
+									"name": "credentials_issue:options.credentialStatus.type:invalid_value",
 									"event": [
 										{
 											"listen": "test",
@@ -1800,7 +1800,7 @@
 							"name": "Bad Auth",
 							"item": [
 								{
-									"name": "missing_auth",
+									"name": "credentials_issue:missing_auth",
 									"event": [
 										{
 											"listen": "test",
@@ -1865,7 +1865,7 @@
 									"response": []
 								},
 								{
-									"name": "missing_scope:issue_credentials",
+									"name": "credentials_issue:missing_scope:issue_credentials",
 									"event": [
 										{
 											"listen": "test",
@@ -2000,7 +2000,7 @@
 					"name": "Happy Path",
 					"item": [
 						{
-							"name": "base",
+							"name": "credentials_issue",
 							"event": [
 								{
 									"listen": "test",
@@ -2064,7 +2064,7 @@
 							"response": []
 						},
 						{
-							"name": "credential:opt.id",
+							"name": "credentials_issue:credential:opt.id",
 							"event": [
 								{
 									"listen": "test",
@@ -2131,7 +2131,7 @@
 							"response": []
 						},
 						{
-							"name": "credential:alt.issuer:object",
+							"name": "credentials_issue:credential:alt.issuer:object",
 							"event": [
 								{
 									"listen": "test",
@@ -2198,7 +2198,7 @@
 							"response": []
 						},
 						{
-							"name": "credential:alt.issuer.object:opt.id",
+							"name": "credentials_issue:credential:alt.issuer.object:opt.id",
 							"event": [
 								{
 									"listen": "test",
@@ -2265,7 +2265,7 @@
 							"response": []
 						},
 						{
-							"name": "credential:alt.credentialSubject.object",
+							"name": "credentials_issue:credential:alt.credentialSubject.object",
 							"event": [
 								{
 									"listen": "test",
@@ -2332,7 +2332,7 @@
 							"response": []
 						},
 						{
-							"name": "credential:alt.credentialSubject.object:opt.id",
+							"name": "credentials_issue:credential:alt.credentialSubject.object:opt.id",
 							"event": [
 								{
 									"listen": "test",
@@ -2399,7 +2399,7 @@
 							"response": []
 						},
 						{
-							"name": "options:opt.created",
+							"name": "credentials_issue:options:opt.created",
 							"event": [
 								{
 									"listen": "test",
@@ -2466,7 +2466,7 @@
 							"response": []
 						},
 						{
-							"name": "options:opt.credentialStatus",
+							"name": "credentials_issue:options:opt.credentialStatus",
 							"event": [
 								{
 									"listen": "test",
@@ -2533,7 +2533,7 @@
 							"response": []
 						},
 						{
-							"name": "options:opt.credentialStatus Copy",
+							"name": "credentials_issue:options:opt.credentialStatus.type",
 							"event": [
 								{
 									"listen": "test",


### PR DESCRIPTION
Add a string to conformance requests for /credentials/issue so that they can be more easily identified in test output.

FIX: #270