### PR TITLE
Optional security for public credentials

### DIFF
--- a/docs/openapi/resources/credential.yml
+++ b/docs/openapi/resources/credential.yml
@@ -6,6 +6,7 @@ get:
   tags:
     - Credentials
   security:
+    - {}
     - OAuth2:
         - 'read:credentials'
   parameters:


### PR DESCRIPTION
I'm fairly sure this is the right syntax for optional security. The swagger editor accepts it too:

![image](https://user-images.githubusercontent.com/34443212/179085121-2d017b2d-ca66-4b0c-b7ba-4cd0cb1639ae.png)
