### PR TITLE
chore: update schema for did document @context

### DIFF
--- a/docs/openapi/schemas/TraceabilityAPIDIDWebDocument.yml
+++ b/docs/openapi/schemas/TraceabilityAPIDIDWebDocument.yml
@@ -1,10 +1,15 @@
 title: Traceability API DID Web Document
 type: object
 properties:
-  "@context":
-    type: array
-    items:
-      type: string
+  '@context':
+    oneOf:
+      - type: string
+      - type: array
+        uniqueItems: true
+        items:
+          oneOf:
+            - type: string
+            - type: object
   id:
     type: string
   alsoKnownAs:


### PR DESCRIPTION
This PR updates the openapi schema spec for the traceability API DID Web Document to match the did-core spec by allowing `@context` to be a string or an array containing string or object type items.

FIX: #282