### PR TITLE
feat: add flags to specify report type

### DIFF
--- a/.github/workflows/conformance-run.yml
+++ b/.github/workflows/conformance-run.yml
@@ -111,7 +111,7 @@ jobs:
       # Compile interactive report
       - name: Build Conformance Report
         working-directory: ./reporting
-        run: ./reporter.py --mode ci
+        run: ./reporter.py --mode ci --conformance
 
       # Compiled report must be added to artifact
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/interoperability-report.yml
+++ b/.github/workflows/interoperability-report.yml
@@ -641,9 +641,9 @@ jobs:
       - run: pip install -r ./reporting/requirements.txt
 
         # Build interactive report
-      - name: Build Interactive Report
+      - name: Build Interoperability Report
         working-directory: ./reporting
-        run: ./reporter.py --mode ci
+        run: ./reporter.py --mode ci --interoperability
 
       # Publish reports subfolder to GitHub Pages
       - name: Publish Reports

--- a/reporting/README.md
+++ b/reporting/README.md
@@ -20,23 +20,31 @@ $ conda activate reporting
 
 ## Run reporting
 
-The reporter can be run with the following command:
+The reporter can be run from your local machine with one of the following command:
 
 ```bash
-$ ./reporter.py
+$ ./reporter.py --conformance
+$ ./reporter.py --interoperability
 ```
 
-It will automatically fetch the latest interop test results, process them, and launch a server hosting the dashboard at [http://localhost:8050/](http://localhost:8050/)
+It will automatically fetch the latest test results, process them, and launch a server hosting the dashboard at [http://localhost:8050/](http://localhost:8050/)
 
-Test results are sourced from the JSON test results published here:
+Test results are sourced from the JSON test results published in github pages in one of the following locations based on the provided command-line options (either `--conformance` or `--interoperability`)
 
-[https://w3c-ccg.github.io/traceability-interop/reports/](https://w3c-ccg.github.io/traceability-interop/reports/)
+- [Interoperability test results](https://w3c-ccg.github.io/traceability-interop/reports/interoperability/index.json)
+- [Conformance test results](https://w3c-ccg.github.io/traceability-interop/reports/conformance/index.json)
 
+The reporter can also be run in CI mode, which will find test output in the `docs/reports` folder on the test runner instead of downloading published report output. If you want to test this mode locally, i.e., during development, you will need to run the postman test suite and post-process the results into the `docs/reports` folder yourself before running `reporter.py`.
 
-To get a list of reporter options, you can execute the reporter with the help parameter:
+```bash
+$ ./reporter.py --mode ci --conformance
+$ ./reporter.py --mode ci --interoperability
+```
+
+To get a full list of reporter options, you can execute the reporter with the help parameter:
 ```bash
 $ ./reporter.py -h
-usage: reporter.py [-h] [--mode [{all,data,html,dashboard,ci}]]
+usage: reporter.py [-h] [--mode [{all,data,html,dashboard,ci}]] (-c | -i)
 
 Interop test results reporting utility
 
@@ -44,15 +52,20 @@ optional arguments:
   -h, --help            show this help message and exit
   --mode [{all,data,html,dashboard,ci}]
                         mode to run the reporter in
-```
 
+Report Type:
+  One of the following options MUST be specified.
+
+  -c, --conformance     generate a report based on the most recently published conformance testing output.
+  -i, --interop         generate a report based on the most recently publised interoperability testing output.
+```
 
 ## Module Description
 
 There are three main modules:
 
 - `./postman_reporter/report_data.py` — go get the data, link it up, create appropriate data frames, and store them as CSV for easy use
-- `./postman_reporter/report_static.py` — generate a static HTML report for use with gh-pages (IN-PROGRESS)
+- `./postman_reporter/report_static.py` — generate a static HTML report for use with gh-pages
 - `./postman_reporter/report_dashboard.py` — the latter half of this app that spins up a dash app on flask for actually working with the test results
 - `reporter.py` — the main binary that runs one or more modules as listed above, based on command line arguments
 

--- a/reporting/postman_reporter/report_config.py
+++ b/reporting/postman_reporter/report_config.py
@@ -1,4 +1,4 @@
-URL = "https://w3id.org/traceability/interoperability/reports/"
+REPORTS_BASE_URL = "https://w3id.org/traceability/interoperability/reports"
 TEMPLATE_FILE = "./assets/template.j2"
 DATA_DIR = "./data/"
 CI_DIR = "../docs/reports"

--- a/reporting/postman_reporter/report_data.py
+++ b/reporting/postman_reporter/report_data.py
@@ -5,7 +5,6 @@ import warnings
 from datetime import datetime
 
 import pandas as pd
-import requests
 
 # disable warnings
 warnings.filterwarnings("ignore")
@@ -17,25 +16,8 @@ from tqdm import tqdm
 tqdm.pandas()
 
 
-def _json_from_url(url):
-    return json.loads(requests.get(url).text)
-
-
-def _reports_from_url(url):
-    def func():
-        data = json.loads(requests.get(url).text)
-        items = data["items"]
-        report_sources = []
-        for item in items:
-            if ".json" in item:
-                report_sources.append(item)
-        return report_sources
-
-    return func
-
-
 # %% process initial json
-def getData(get_reports=_reports_from_url(URL), get_json=_json_from_url):
+def getData(get_reports, get_json):
 
     report_sources = get_reports()
 

--- a/reporting/reporter.py
+++ b/reporting/reporter.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
         dest="type",
         action="store_const",
         const="conformance",
-        help="generate a report based on the most recently published conformance testing output.",
+        help="generate a report based on the most recently published conformance testing output",
     )
 
     group.add_argument(
@@ -140,7 +140,7 @@ if __name__ == "__main__":
         dest="type",
         action="store_const",
         const="interoperability",
-        help="generate a report based on the most recently publised interoperability testing output.",
+        help="generate a report based on the most recently published interoperability testing output",
     )
 
     args = parser.parse_args()

--- a/reporting/reporter.py
+++ b/reporting/reporter.py
@@ -4,12 +4,34 @@ import glob
 import json
 import os
 
+import requests
 from jinja2 import Environment, FileSystemLoader
 from postman_reporter import report_config, report_dashboard, report_data, report_static
 
 
-def runData():
-    report_data.getData()
+def runData(args):
+    def _json_from_url(url):
+        return json.loads(requests.get(url).text)
+
+    def _reports_from_url(url):
+        def func():
+            data = json.loads(requests.get(url).text)
+            items = data["items"]
+            report_sources = []
+            for item in items:
+                if ".json" in item:
+                    report_sources.append(item)
+            return report_sources
+
+        return func
+
+    url = os.path.join(report_config.REPORTS_BASE_URL, args.type, "index.json")
+
+    report_data.getData(
+        get_reports=_reports_from_url(url),
+        get_json=_json_from_url,
+    )
+
     return 0
 
 
@@ -69,7 +91,7 @@ def main(args):
 
     # now check args
     if args.mode == "all" or args.mode == "data":
-        runData()
+        runData(args)
 
     if args.mode == "all" or args.mode == "html":
         runHtml()
@@ -93,6 +115,32 @@ if __name__ == "__main__":
         nargs="?",
         choices=["all", "data", "html", "dashboard", "ci"],
         help="mode to run the reporter in",
+    )
+
+    # Mutually-exclusive group must be nested in an argument group in order to
+    # support providing a title and description in help output.
+    group = parser.add_argument_group(
+        "Report Type",
+        "One of the following options MUST be specified.",
+    )
+    group = group.add_mutually_exclusive_group(required=True)
+
+    group.add_argument(
+        "-c",
+        "--conformance",
+        dest="type",
+        action="store_const",
+        const="conformance",
+        help="generate a report based on the most recently published conformance testing output.",
+    )
+
+    group.add_argument(
+        "-i",
+        "--interoperability",
+        dest="type",
+        action="store_const",
+        const="interoperability",
+        help="generate a report based on the most recently publised interoperability testing output.",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
This PR modifies the `reporter.py` script to accept one of two new command line options, `--conformance (-c)` and `--interoperability (-i)`. These options allow the script the automatically download test suite output from the appropriate subfolder of `https://w3id.org/traceability/interoperability/reports` when not running in `ci` mode.

Additionally, this facilitates a solution to #272 by allowing the script to choose an appropriate HTML template do differentiate between conformance and interoperability reporting.

FIX: #302