### PR TITLE
feat: add issuer id uri tests for credentials/issue

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -949,6 +949,75 @@
 									"response": []
 								},
 								{
+									"name": "credentials_issue.credential.issuer:invalid_value",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"let rawBody = pm.variables.get(\"rawBody\");",
+													"",
+													"// credential.issuer must be a URI when it is a string value.",
+													"rawBody.credential.issuer = \"not.a.uri\";",
+													"",
+													"// Request body must be serialized before sending over the wire.",
+													"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/issue",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"issue"
+											]
+										}
+									},
+									"response": []
+								},
+								{
 									"name": "credentials_issue:credential.issuer.id:wrong_type",
 									"event": [
 										{
@@ -981,6 +1050,75 @@
 													"",
 													"// Request body must be serialized before sending over the wire.",
 													"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/issue",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"issue"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_issue.credential.issuer.id:invalid_value",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"let rawBody = pm.variables.get(\"rawBody\");",
+													"",
+													"// credential.issuer.id must be a URI when present.",
+													"rawBody.credential.issuer = {\"id\": \"not.a.uri\"};",
+													"",
+													"// Request body must be serialized before sending over the wire.",
+													"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));",
+													""
 												],
 												"type": "text/javascript"
 											}


### PR DESCRIPTION
This PR adds negative tests to ensure that providers return `400 Bad Request` if the issuer ID in a `credentials/issue` request is a string but is not in uri format.

FIX: #294