### PR TITLE
feat: require 'challenge' property in prove presentation options

### DIFF
--- a/docs/openapi/schemas/PresentationOptions.yml
+++ b/docs/openapi/schemas/PresentationOptions.yml
@@ -1,6 +1,8 @@
 title: Prove Presentation Options
 type: object
 description: Options for proving a verifiable presentation
+required:
+  - challenge
 properties:
   domain:
      type: string


### PR DESCRIPTION
This PR makes the `challenge` property of [PresentationsOptions.yml](https://github.com/w3c-ccg/traceability-interop/blob/main/docs/openapi/schemas/PresentationOptions.yml) required.

FIX: #259