### PR TITLE
Fix how endpoints without security is specified

### DIFF
--- a/docs/openapi/resources/presentation-available.yml
+++ b/docs/openapi/resources/presentation-available.yml
@@ -4,7 +4,6 @@ post:
   description: Start a presentation exchange flow
   tags:
     - Presentations
-  security: []
   requestBody:
     description: Description of the flow
     content:

--- a/docs/openapi/resources/presentation-submissions.yml
+++ b/docs/openapi/resources/presentation-submissions.yml
@@ -4,7 +4,6 @@ post:
   description: End a presentation exchange flow
   tags:
     - Presentations
-  security: []
   requestBody:
     description: A Verifiable Presentation to Store
     content:


### PR DESCRIPTION
`/presentations/available` and `/presentations/submissions` are specified with `security: []`. While that does seem like a way to explicitly state that security is not allowed, the OAS doesn't seem to understand it, showing a lock for those endpoints: 
![image](https://user-images.githubusercontent.com/34443212/180419451-95cdd5cd-e71b-433b-af01-044d878b6347.png)

This PR removes `security: []`, which is also how we specified [getTraceabilityAPIConfiguration](https://w3c-ccg.github.io/traceability-interop/openapi/#get-/did.json). 