### PR TITLE
Flexible error details

### DIFF
--- a/docs/openapi/schemas/Error.yml
+++ b/docs/openapi/schemas/Error.yml
@@ -9,4 +9,10 @@ properties:
   message:
     type: string
   details:
-    type: object
+    oneOf:
+    - type: string
+    - type: array
+      items:
+        type: string
+    - type: object
+      additionalProperties: true

--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -3695,22 +3695,22 @@
 		},
 		{
 			"key": "responseSchema400",
-			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"code\",\"message\"],\"properties\":{\"code\":{\"type\":\"integer\"},\"message\":{\"type\":\"string\"},\"details\":{\"type\":\"object\"}}},{\"type\":\"object\",\"properties\":{\"code\":{\"enum\":[400]},\"message\":{\"enum\":[\"Bad Request: Your request body does not conform to the required schema\"]}}}]}",
+			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"code\",\"message\"],\"properties\":{\"code\":{\"type\":\"integer\"},\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"code\":{\"enum\":[400]},\"message\":{\"enum\":[\"Bad Request: Your request body does not conform to the required schema\"]}}}]}",
 			"type": "string"
 		},
 		{
 			"key": "responseSchema401",
-			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"code\",\"message\"],\"properties\":{\"code\":{\"type\":\"integer\"},\"message\":{\"type\":\"string\"},\"details\":{\"type\":\"object\"}}},{\"type\":\"object\",\"properties\":{\"code\":{\"enum\":[401]},\"message\":{\"enum\":[\"Unauthorized: This endpoint requires an OAuth2 bearer token\"]}}}]}",
+			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"code\",\"message\"],\"properties\":{\"code\":{\"type\":\"integer\"},\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"code\":{\"enum\":[401]},\"message\":{\"enum\":[\"Unauthorized: This endpoint requires an OAuth2 bearer token\"]}}}]}",
 			"type": "string"
 		},
 		{
 			"key": "responseSchema403",
-			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"code\",\"message\"],\"properties\":{\"code\":{\"type\":\"integer\"},\"message\":{\"type\":\"string\"},\"details\":{\"type\":\"object\"}}},{\"type\":\"object\",\"properties\":{\"code\":{\"enum\":[403]},\"message\":{\"enum\":[\"Forbidden: OAuth2 bearer token does not have the required scope\"]}}}]}",
+			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"code\",\"message\"],\"properties\":{\"code\":{\"type\":\"integer\"},\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"code\":{\"enum\":[403]},\"message\":{\"enum\":[\"Forbidden: OAuth2 bearer token does not have the required scope\"]}}}]}",
 			"type": "string"
 		},
 		{
 			"key": "responseSchema500",
-			"value": "{\"type\":\"object\",\"required\":[\"code\",\"message\"],\"properties\":{\"code\":{\"type\":\"integer\"},\"message\":{\"type\":\"string\"},\"details\":{\"type\":\"object\"}}}",
+			"value": "{\"type\":\"object\",\"required\":[\"code\",\"message\"],\"properties\":{\"code\":{\"type\":\"integer\"},\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}",
 			"type": "string"
 		},
 		{


### PR DESCRIPTION
Currently, the error schema requires the details member to be an object with arbitrary properties.

This PR relaxes the error schema to allow the details member to be a string, an array of strings, or an object with arbitrary properties.