### PR TITLE
chore: correctly populate request body

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -2215,7 +2215,7 @@
 											"script": {
 												"exec": [
 													"// Request body must be serialized before sending over the wire.",
-													"pm.variables.set(\"requestBody\", JSON.stringify(pm.variables.get(\"requestBody\")));"
+													"pm.variables.set(\"requestBody\", JSON.stringify(pm.variables.get(\"rawBody\")));"
 												],
 												"type": "text/javascript"
 											}
@@ -2293,7 +2293,7 @@
 													"});",
 													"",
 													"// Request body must be serialized before sending over the wire.",
-													"pm.variables.set(\"requestBody\", JSON.stringify(pm.variables.get(\"requestBody\")));"
+													"pm.variables.set(\"requestBody\", JSON.stringify(pm.variables.get(\"rawBody\")));"
 												],
 												"type": "text/javascript"
 											}


### PR DESCRIPTION
This PR fixes a typo in variable name used when populating the request body for auth-related negative testing for the `/credentials/issue` endpoint.