### PR TITLE
chore: fix test naming

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -3507,7 +3507,7 @@
 									"response": []
 								},
 								{
-									"name": "credentials_verify:missing_scope:update_credentials",
+									"name": "credentials_verify:missing_scope:verify_credentials",
 									"event": [
 										{
 											"listen": "prerequest",


### PR DESCRIPTION
This PR fixes the name of the negative missing scope auth test for `/credentials/verify` endpoint.