### PR TITLE
chore: add conformance test stubs for remaining endpoints

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -3632,6 +3632,362 @@
 					}
 				}
 			]
+		},
+		{
+			"name": "Presentations Prove",
+			"item": [
+				{
+					"name": "Negative Testing",
+					"item": [
+						{
+							"name": "Bad Auth",
+							"item": [
+								{
+									"name": "presentations_prove:missing_auth",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 401\", function () {",
+													" pm.response.to.have.status(401);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema401\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{API_BASE_URL}}/presentations/prove",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"presentations",
+												"prove"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "presentations_prove:missing_scope:prove_presentations",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"// Obtain an access token without the required \"prove:presentations\" scope",
+													"utils(pm).getAccessToken('', (err, res) => {",
+													"    pm.expect(err).to.be.null;",
+													"    pm.variables.set('currentAccessToken', res.json().access_token)",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 403\", function () {",
+													" pm.response.to.have.status(403);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema403\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{currentAccessToken}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{API_BASE_URL}}/presentations/prove",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"presentations",
+												"prove"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"auth": {
+								"type": "noauth"
+							},
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								}
+							]
+						}
+					]
+				}
+			],
+			"auth": {
+				"type": "bearer"
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"// Obtain an access token with the required \"prove:presentations\" scope",
+							"if (!pm.variables.get('currentAccessToken')) {",
+							"    utils(pm).getAccessToken('prove:presentations', (err, res) => {",
+							"        pm.expect(err).to.be.null;",
+							"        pm.variables.set('currentAccessToken', res.json().access_token)",
+							"    });",
+							"}"
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Presentations Verify",
+			"item": [
+				{
+					"name": "Negative Testing",
+					"item": [
+						{
+							"name": "Bad Auth",
+							"item": [
+								{
+									"name": "presentations_verify:missing_auth",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 401\", function () {",
+													" pm.response.to.have.status(401);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema401\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{API_BASE_URL}}/presentations/verify",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"presentations",
+												"verify"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "presentations_verify:missing_scope:verify_presentations",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"// Obtain an access token without the required \"verify:presentations\" scope",
+													"utils(pm).getAccessToken('', (err, res) => {",
+													"    pm.expect(err).to.be.null;",
+													"    pm.variables.set('currentAccessToken', res.json().access_token)",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 403\", function () {",
+													" pm.response.to.have.status(403);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema403\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{currentAccessToken}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{API_BASE_URL}}/presentations/verify",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"presentations",
+												"verify"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"auth": {
+								"type": "noauth"
+							},
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								}
+							]
+						}
+					]
+				}
+			],
+			"auth": {
+				"type": "bearer"
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"// Obtain an access token with the required \"verify:presentations\" scope",
+							"if (!pm.variables.get('currentAccessToken')) {",
+							"    utils(pm).getAccessToken('verify:presentations', (err, res) => {",
+							"        pm.expect(err).to.be.null;",
+							"        pm.variables.set('currentAccessToken', res.json().access_token)",
+							"    });",
+							"}"
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Presentations Available",
+			"item": []
+		},
+		{
+			"name": "Presentations Submissions",
+			"item": []
 		}
 	],
 	"event": [


### PR DESCRIPTION
This PR adds stubs for conformance testing of the following endpoints:
* `/presentations/prove`
* `/presentations/verify`
* `/presentations/available`
* `/presentations/submissions`

This includes negative auth testing for `/presentations/prove` (#245) and `/presentations/verify` (#244). The folders for `/presentations/available` and `/presentations/submissions` are just empty stubs that will help prevent conflicts in the postman file when they are implemented in separate pull requests later.