### PR TITLE
chore: test that subject matches request

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -2393,6 +2393,11 @@
 											" const { issuer } = pm.response.json();",
 											" pm.expect(issuer).to.equal(pm.variables.get(\"credential_issuer_id\"))",
 											"});",
+											"",
+											"pm.test(\"response credentialSubject matches request credential.credentialSubject\", function() {",
+											" const { credentialSubject } = pm.response.json();",
+											" pm.expect(credentialSubject).to.equal(pm.variables.get(\"credential_subject\"))",
+											"});",
 											""
 										],
 										"type": "text/javascript"
@@ -2594,7 +2599,12 @@
 											"",
 											"pm.test(\"response issuer matches request credential.issuer.id\", function() {",
 											" const { issuer } = pm.response.json();",
-											" pm.expect(issuer).to.equal(pm.variables.get(\"credential_issuer_id\"))",
+											" // Implementations may reduce object with just \"id\" property to a bare string",
+											" if (typeof issuer === 'string') {",
+											"  pm.expect(issuer).to.equal(pm.variables.get(\"credential_issuer_id\"))",
+											" } else {",
+											"  pm.expect(issuer.id).to.equal(pm.variables.get(\"credential_issuer_id\"))",
+											" }",
 											"});",
 											""
 										],
@@ -2730,7 +2740,16 @@
 											" const schemaString = pm.collectionVariables.get(\"responseSchema201CredentialsIssue\");",
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 											"});",
-											""
+											"",
+											"pm.test(\"response credentialSubject matches request credential.credentialSubject.id\", function() {",
+											" const { credentialSubject } = pm.response.json();",
+											" // Implementations may reduce object with just \"id\" property to a bare string",
+											" if (typeof credentialSubject === 'string') {",
+											"  pm.expect(credentialSubject).to.equal(pm.variables.get(\"credential_subject\"))",
+											" } else {",
+											"  pm.expect(credentialSubject.id).to.equal(pm.variables.get(\"credential_subject\"))",
+											" }",
+											"});"
 										],
 										"type": "text/javascript"
 									}


### PR DESCRIPTION
This PR validates that the `credentialSubject` returned from a `credentials/issue` request matches the `credentialSubject` provided in the request body.

FIX: #313