### PR TITLE
chore: add negative testing for unknown issuers

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -1011,6 +1011,75 @@
 									"response": []
 								},
 								{
+									"name": "credentials_issue.credential.issuer:unknown",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"let rawBody = pm.variables.get(\"rawBody\");",
+													"",
+													"// credential.issuer must be known to the endpoint.",
+													"rawBody.credential.issuer = \"urn:uuid:{{$randomUUID}}\";",
+													"",
+													"// Request body must be serialized before sending over the wire.",
+													"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/issue",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"issue"
+											]
+										}
+									},
+									"response": []
+								},
+								{
 									"name": "credentials_issue:credential.issuer.id:wrong_type",
 									"event": [
 										{
@@ -1108,6 +1177,75 @@
 													"",
 													"// credential.issuer.id must be a URI when present.",
 													"rawBody.credential.issuer = {\"id\": \"not.a.uri\"};",
+													"",
+													"// Request body must be serialized before sending over the wire.",
+													"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/issue",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"issue"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_issue.credential.issuer.id:unknown",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"let rawBody = pm.variables.get(\"rawBody\");",
+													"",
+													"// credential.issuer.id must be a URI when present.",
+													"rawBody.credential.issuer = {\"id\": \"urn:uuid:{{$randomUUID}}\"};",
 													"",
 													"// Request body must be serialized before sending over the wire.",
 													"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));",


### PR DESCRIPTION
This PR adds negative testing to ensure that an issuer does not issue a credential if it does not have key materials for the requested "credential.issuer".

FIX: #311 