### PR TITLE
feat: update tests to reflect required nature of issuer.id property

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -1080,6 +1080,74 @@
 									"response": []
 								},
 								{
+									"name": "credentials_issue:credential.issuer.id:missing",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"let rawBody = pm.variables.get(\"rawBody\");",
+													"",
+													"// credential.issuer.id is required when issuer is in object format",
+													"rawBody.credential.issuer = {};",
+													"",
+													"// Request body must be serialized before sending over the wire.",
+													"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/issue",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"issue"
+											]
+										}
+									},
+									"response": []
+								},
+								{
 									"name": "credentials_issue:credential.issuer.id:wrong_type",
 									"event": [
 										{
@@ -1106,8 +1174,7 @@
 												"exec": [
 													"let rawBody = pm.variables.get(\"rawBody\");",
 													"",
-													"// credential.issuer can be an object with an optional \"id\"",
-													"// property that must be a string when present.",
+													"// credential.issuer.id must be a string.",
 													"rawBody.credential.issuer = {\"id\": [\"arrays are invalid\"]};",
 													"",
 													"// Request body must be serialized before sending over the wire.",
@@ -1175,7 +1242,7 @@
 												"exec": [
 													"let rawBody = pm.variables.get(\"rawBody\");",
 													"",
-													"// credential.issuer.id must be a URI when present.",
+													"// credential.issuer.id string must be a URI.",
 													"rawBody.credential.issuer = {\"id\": \"not.a.uri\"};",
 													"",
 													"// Request body must be serialized before sending over the wire.",
@@ -1244,7 +1311,7 @@
 												"exec": [
 													"let rawBody = pm.variables.get(\"rawBody\");",
 													"",
-													"// credential.issuer.id must be a URI when present.",
+													"// credential.issuer.id string must be known to the implementation.",
 													"rawBody.credential.issuer = {\"id\": \"urn:uuid:{{$randomUUID}}\"};",
 													"",
 													"// Request body must be serialized before sending over the wire.",
@@ -2653,74 +2720,7 @@
 							"response": []
 						},
 						{
-							"name": "credentials_issue:credential:alt.issuer:object",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"pm.test(\"status code is 201\", function () {",
-											" pm.response.to.have.status(201);",
-											"});",
-											"",
-											"pm.test(\"response validates against schema\", function() {",
-											" const schemaString = pm.collectionVariables.get(\"responseSchema201CredentialsIssue\");",
-											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
-											"});",
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"exec": [
-											"let rawBody = pm.variables.get(\"rawBody\");",
-											"",
-											"// credential.issuer can be an object with optional 'id' element.",
-											"rawBody.credential.issuer = {};",
-											"",
-											"// Request body must be serialized before sending over the wire.",
-											"pm.variables.set(\"requestBody\", JSON.stringify(pm.variables.get(\"rawBody\")));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Accept",
-										"value": "application/json",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{requestBody}}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{API_BASE_URL}}/credentials/issue",
-									"host": [
-										"{{API_BASE_URL}}"
-									],
-									"path": [
-										"credentials",
-										"issue"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "credentials_issue:credential:alt.issuer.object:opt.id",
+							"name": "credentials_issue:credential:alt.issuer.object",
 							"event": [
 								{
 									"listen": "test",
@@ -2755,7 +2755,7 @@
 										"exec": [
 											"let rawBody = pm.variables.get(\"rawBody\");",
 											"",
-											"// credential.issuer can be an object with optional 'id' element",
+											"// credential.issuer can be an object with required 'id' element",
 											"rawBody.credential.issuer = {\"id\": pm.variables.get(\"credential_issuer_id\") };",
 											"",
 											"// Request body must be serialized before sending over the wire.",


### PR DESCRIPTION
This PR updates existing conformance testing to reflect the updates from PR #288 (`issuer.id` is now required when `issuer` is in object format).

FIX: #338 