### PR TITLE
chore: test issuanceDate matches requested value

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -2603,6 +2603,11 @@
 											" const { credentialSubject } = pm.response.json();",
 											" pm.expect(credentialSubject).to.equal(pm.variables.get(\"credential_subject\"))",
 											"});",
+											"",
+											"pm.test(\"response issuanceDate matches request credential.issuanceDate\", function() {",
+											" const { issuanceDate } = pm.response.json();",
+											" pm.expect(issuanceDate).to.equal(pm.variables.get(\"issuance_date\"))",
+											"});",
 											""
 										],
 										"type": "text/javascript"
@@ -2615,7 +2620,7 @@
 											"let rawBody = pm.variables.get(\"rawBody\");",
 											"",
 											"// Request body must be serialized before sending over the wire.",
-											"pm.variables.set(\"requestBody\", JSON.stringify(pm.variables.get(\"rawBody\")));"
+											"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
 										],
 										"type": "text/javascript"
 									}
@@ -2682,7 +2687,7 @@
 											"rawBody.credential.id = pm.variables.get(\"credential_id\");",
 											"",
 											"// Request body must be serialized before sending over the wire.",
-											"pm.variables.set(\"requestBody\", JSON.stringify(pm.variables.get(\"rawBody\")));"
+											"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
 										],
 										"type": "text/javascript"
 									}
@@ -2759,7 +2764,7 @@
 											"rawBody.credential.issuer = {\"id\": pm.variables.get(\"credential_issuer_id\") };",
 											"",
 											"// Request body must be serialized before sending over the wire.",
-											"pm.variables.set(\"requestBody\", JSON.stringify(pm.variables.get(\"rawBody\")));"
+											"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
 										],
 										"type": "text/javascript"
 									}
@@ -2826,7 +2831,7 @@
 											"rawBody.credential.credentialSubject = {};",
 											"",
 											"// Request body must be serialized before sending over the wire.",
-											"pm.variables.set(\"requestBody\", JSON.stringify(pm.variables.get(\"rawBody\")));"
+											"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
 										],
 										"type": "text/javascript"
 									}
@@ -2902,7 +2907,7 @@
 											"rawBody.credential.credentialSubject = {\"id\": pm.variables.get(\"credential_subject\") };",
 											"",
 											"// Request body must be serialized before sending over the wire.",
-											"pm.variables.set(\"requestBody\", JSON.stringify(pm.variables.get(\"rawBody\")));"
+											"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
 										],
 										"type": "text/javascript"
 									}
@@ -2969,7 +2974,7 @@
 											"rawBody.options.created = \"an arbitrary string\";",
 											"",
 											"// Request body must be serialized before sending over the wire.",
-											"pm.variables.set(\"requestBody\", JSON.stringify(pm.variables.get(\"rawBody\")));"
+											"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
 										],
 										"type": "text/javascript"
 									}
@@ -3036,7 +3041,7 @@
 											"rawBody.options.credentialStatus = {};",
 											"",
 											"// Request body must be serialized before sending over the wire.",
-											"pm.variables.set(\"requestBody\", JSON.stringify(pm.variables.get(\"rawBody\")));"
+											"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
 										],
 										"type": "text/javascript"
 									}
@@ -3103,7 +3108,7 @@
 											"rawBody.options.credentialStatus = {\"type\": \"RevocationList2020Status\"};",
 											"",
 											"// Request body must be serialized before sending over the wire.",
-											"pm.variables.set(\"requestBody\", JSON.stringify(pm.variables.get(\"rawBody\")));"
+											"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
 										],
 										"type": "text/javascript"
 									}
@@ -3183,6 +3188,8 @@
 							"// first alternate version of any 'oneOf' elements defined in the",
 							"// OpenAPI schema.",
 							"",
+							"pm.variables.set('issuance_date', '2006-01-02T15:04:05Z');",
+							"",
 							"pm.variables.set(\"rawBody\", {",
 							"    \"credential\": {",
 							"        \"@context\": [",
@@ -3192,7 +3199,7 @@
 							"            \"VerifiableCredential\"",
 							"        ],",
 							"        \"issuer\": \"{{credential_issuer_id}}\",",
-							"        \"issuanceDate\": \"2010-01-01T19:23:24Z\",",
+							"        \"issuanceDate\": \"{{issuance_date}}\",",
 							"        \"credentialSubject\": \"{{credential_subject}}\"",
 							"    },",
 							"    \"options\": {",


### PR DESCRIPTION
This PR validates that the `issuanceDate` in the reponse to `credentials/issue` matches the `issuanceDate` in the request.

FIX: #314 