### PR TITLE
chore: split report template by report type

### DIFF
--- a/reporting/assets/conformance.j2
+++ b/reporting/assets/conformance.j2
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="UTF-8">
+    <title>W3C Supply Chain Traceability Conformance Test Results</title>
+    <meta name="description"
+        content="Discovery and exchange mechanisms for W3C Verifible Credentials (VCs), particularly as they relate to supply chain use cases. The specification extends the core Verifiable Credential API definitions described in the VC-API specification, adding cross-security domain interactions. Systems implementing the traceability-interop specification can exchange Verifiable Credentials over HTTP within proofed Verifiable Presentations. Exchanged Verifiable Credentials often implement schemas defined in the traceability-vocab specification." />
+    <style>
+        html {
+            height: 100%;
+            max-width: 100%;
+        }
+
+        body {
+            width: 100%;
+            max-width: 100%;
+            min-width: 100%;
+            min-height: 100%;
+            max-width: 100%;
+        }
+
+        #page-content {
+            margin-left: 1rem !important;
+            margin-right: 1rem !important;
+        }
+
+        .card {
+            padding: 0;
+            width: 20rem;
+            margin-right: 8px;
+            margin-bottom: 8px;
+        }
+
+        .card-text {
+            color: #999999;
+            margin-bottom: 5.5px;
+            font-size: 14px;
+            display: block;
+        }
+
+        .card-title {
+            font-weight: bold;
+            font-size: 30px;
+            margin-top: 0;
+            margin-bottom: 0px;
+        }
+
+        .cell-markdown {
+            padding: 4px;
+        }
+
+        .cell-markdown p {
+            margin-bottom: 0;
+        }
+
+        .dash-table-container .dash-spreadsheet-container .dash-spreadsheet-inner input:not([type=radio]):not([type=checkbox]) {
+            color: #f3f3f3 !important;
+        }
+
+        .card {
+            padding: 0;
+            width: 20rem;
+            margin-right: 8px;
+            margin-bottom: 8px;
+        }
+
+        .card-text {
+            color: #999999;
+            margin-bottom: 5.5px;
+            font-size: 14px;
+            display: block;
+        }
+
+        .card-title {
+            font-weight: bold;
+            font-size: 30px;
+            margin-top: 0;
+            margin-bottom: 0px;
+        }
+
+        .cell-markdown {
+            padding: 4px;
+        }
+
+        .cell-markdown p {
+            margin-bottom: 0;
+        }
+
+        .dash-table-container .dash-spreadsheet-container .dash-spreadsheet-inner input:not([type=radio]):not([type=checkbox]) {
+            color: #f3f3f3 !important;
+        }
+    </style>
+    <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+    <link rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/bootswatch@5.1.3/dist/darkly/bootstrap.min.css">
+</head>
+
+<body>
+
+    <div id="react-entry-point">
+        <div>
+            <div id="page-content" style="margin-left: 18rem; margin-right: 2rem; padding: 2rem 1rem;">
+                <div class="row">
+                    <h1>Traceability Conformance Test Results</h1>
+                </div>
+                <div class="row">
+                    <div class="col-xl-12">
+                        <div id="overview" class="row" style="margin-bottom: 3em;">
+                            <div class="col-xl-12"></div>
+                        </div>
+                        <div id="summary" class="row" style="margin-bottom: 3em;">
+                            <div class="col-xl-12">
+                                <h2>Summary</h2>
+                                <div style="margin-bottom: 3em; font-size: 1.2em;">
+                                  {{ summary_text }}
+                                </div>
+                                <h3>Provider Summary</h3>
+                                 <div style="margin-bottom: 2em;">
+                                  {% for card in cards_single %}
+                                    {{ card }}
+                                  {% endfor %}
+                                </div>
+                                <div style="margin-bottom:3em;">
+                                  {% for card in cards_multi %}
+                                    {{ card }}
+                                  {% endfor %}
+                                </div>
+                                <h3>Provider &amp; Test Summary</h3>
+                                <div style="width: 60%">
+                                  {{summary_table_single}}
+                                </div><br>
+                                <div style="width: 80%">
+                                  {{summary_table_multi}}
+                                </div><br><br>
+                                <div>
+                                    <div id="test-facets" class="dash-graph">
+                                      {{ facet_tests }}
+                                    </div>
+                                </div><br>
+                            </div>
+                        </div>
+                        <div id="results" class="row"
+                            style="margin-bottom: 3em;">
+                            <div class="col-xl-12">
+                              <h2>Results</h2>
+                              <div class="row">
+                                <div class="col-xl-6">{{ results_chart }}</div>
+                                <div class="col-xl-6">{{ results_tree }}</div>
+                              </div>
+                            </div>
+                        </div>
+                        <div id="details" class="row"
+                            style="margin-bottom: 3em;">
+                            <div class="col-xl-12">
+                                <h2>Details</h2>
+                                <div style="width:100%;max-width:100%">
+                                  {{ details }}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+</body>
+
+</html>

--- a/reporting/assets/interoperability.j2
+++ b/reporting/assets/interoperability.j2
@@ -4,7 +4,7 @@
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="UTF-8">
-    <title>W3C Supply Chain Traceability Interop Test Results</title>
+    <title>W3C Supply Chain Traceability Interoperability Test Results</title>
     <meta name="description"
         content="Discovery and exchange mechanisms for W3C Verifible Credentials (VCs), particularly as they relate to supply chain use cases. The specification extends the core Verifiable Credential API definitions described in the VC-API specification, adding cross-security domain interactions. Systems implementing the traceability-interop specification can exchange Verifiable Credentials over HTTP within proofed Verifiable Presentations. Exchanged Verifiable Credentials often implement schemas defined in the traceability-vocab specification." />
     <style>
@@ -103,7 +103,7 @@
         <div>
             <div id="page-content" style="margin-left: 18rem; margin-right: 2rem; padding: 2rem 1rem;">
                 <div class="row">
-                    <h1>Trace Interop Test Results</h1>
+                    <h1>Traceability Interoperability Test Results</h1>
                 </div>
                 <div class="row">
                     <div class="col-xl-12">

--- a/reporting/postman_reporter/report_config.py
+++ b/reporting/postman_reporter/report_config.py
@@ -1,5 +1,4 @@
 REPORTS_BASE_URL = "https://w3id.org/traceability/interoperability/reports"
-TEMPLATE_FILE = "./assets/template.j2"
 DATA_DIR = "./data/"
 CI_DIR = "../docs/reports"
 DF_PREFIX = ""

--- a/reporting/reporter.py
+++ b/reporting/reporter.py
@@ -6,7 +6,8 @@ import os
 
 import requests
 from jinja2 import Environment, FileSystemLoader
-from postman_reporter import report_config, report_dashboard, report_data, report_static
+from postman_reporter import (report_config, report_dashboard, report_data,
+                              report_static)
 
 
 def runData(args):
@@ -42,11 +43,12 @@ def runDash():
     return 0
 
 
-def runHtml():
+def runHtml(args):
     # Create the jinja2 environment.
     current_directory = os.path.dirname(os.path.abspath(__file__))
     env = Environment(loader=FileSystemLoader(current_directory))
-    template = env.get_template(report_config.TEMPLATE_FILE)
+    path = os.path.join("assets", f"{args.type}.j2")
+    template = env.get_template(path)
     report_static.generate_html(template)
     return 0
 
@@ -94,7 +96,7 @@ def main(args):
         runData(args)
 
     if args.mode == "all" or args.mode == "html":
-        runHtml()
+        runHtml(args)
 
     if args.mode == "all" or args.mode == "dashboard":
         runDash()


### PR DESCRIPTION
This PR updates the report generation system to use separate templates for conformance and interoperability reports, and modifies the report titles to differentiate between the two. This change makes it easier for the reports to diverge as needed.

FIX: #272