### PR TITLE
chore: additional responses for did resolution

### DIFF
--- a/docs/openapi/resources/did.yml
+++ b/docs/openapi/resources/did.yml
@@ -16,9 +16,22 @@ get:
         application/json:
           schema:
             $ref: "../schemas/DidResolutionResponse.yml"
+    "400":
+      description: Invalid DID in path
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '../responses/BadRequest.yml'
+              - type: object
+                properties:
+                  message:
+                    enum: ["Bad Request: Invalid DID"]
     '401':
       $ref: '../responses/Unauthenticated.yml'
     '403':
       $ref: '../responses/Unauthorized.yml'
+    "404":
+      $ref: '../responses/NotFound.yml'
     default:
       $ref: "../responses/UnexpectedError.yml"

--- a/docs/openapi/responses/NotFound.yml
+++ b/docs/openapi/responses/NotFound.yml
@@ -1,0 +1,12 @@
+description: Not Found
+content:
+  application/json:
+    schema:
+      allOf:
+        - $ref: '../schemas/Error.yml'
+        - type: object
+          properties:
+            code:
+              enum: [404]
+            message:
+              enum: ["Not Found: The requested resource could not be found"]

--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "cc41d416-e316-4a7c-aa1b-7c6f06394282",
+		"_postman_id": "691a6d66-244e-4521-a0e5-6768dd6cf6f4",
 		"name": "Conformance Suite",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "4338127"
@@ -58,6 +58,122 @@
 				{
 					"name": "Negative Testing",
 					"item": [
+						{
+							"name": "Bad Request",
+							"item": [
+								{
+									"name": "did:invalid",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400Identifiers\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{API_BASE_URL}}/identifiers/invalid_did",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"identifiers",
+												"invalid_did"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "did:not_found:did_web",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 404\", function () {",
+													" pm.response.to.have.status(404);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema404\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{API_BASE_URL}}/identifiers/did:web:example.com",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"identifiers",
+												"did:web:example.com"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "did:not_found:urn",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 404\", function () {",
+													" pm.response.to.have.status(404);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema404\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{API_BASE_URL}}/identifiers/urn:uuid:{{$randomUUID}}",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"identifiers",
+												"urn:uuid:{{$randomUUID}}"
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
 						{
 							"name": "Bad Auth",
 							"item": [
@@ -4229,6 +4345,11 @@
 			"type": "string"
 		},
 		{
+			"key": "responseSchema404",
+			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"code\",\"message\"],\"properties\":{\"code\":{\"type\":\"integer\"},\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"code\":{\"enum\":[404]},\"message\":{\"enum\":[\"Not Found: The requested resource could not be found\"]}}}]}",
+			"type": "string"
+		},
+		{
 			"key": "responseSchema500",
 			"value": "{\"type\":\"object\",\"required\":[\"code\",\"message\"],\"properties\":{\"code\":{\"type\":\"integer\"},\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}",
 			"type": "string"
@@ -4236,6 +4357,11 @@
 		{
 			"key": "responseSchema200Identifiers",
 			"value": "{\"type\":\"object\",\"required\":[\"didDocument\"],\"properties\":{\"didDocument\":{\"type\":\"object\",\"required\":[\"alsoKnownAs\",\"service\"],\"properties\":{\"alsoKnownAs\":{\"type\":\"array\",\"minItems\":2,\"uniqueItems\":true,\"items\":{\"type\":\"string\"}},\"service\":{\"type\":\"array\",\"minItems\":1,\"items\":{\"type\":\"object\",\"required\":[\"type\",\"serviceEndpoint\"],\"properties\":{\"type\":{\"type\":\"string\"},\"serviceEndpoint\":{\"type\":\"string\"}}}}}},\"didResolutionMetadata\":{\"type\":\"object\"},\"didDocumentMetadata\":{\"type\":\"object\"}}}",
+			"type": "string"
+		},
+		{
+			"key": "responseSchema400Identifiers",
+			"value": "{\"allOf\":[{\"description\":\"Bad Request\",\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"type\":\"object\",\"required\":[\"code\",\"message\"],\"properties\":{\"code\":{\"type\":\"integer\"},\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"code\":{\"enum\":[400]},\"message\":{\"enum\":[\"Bad Request: Your request body does not conform to the required schema\"]}}}]}}}},{\"type\":\"object\",\"properties\":{\"message\":{\"enum\":[\"Bad Request: Invalid DID\"]}}}]}",
 			"type": "string"
 		},
 		{

--- a/tests/update_conformance_schemas.sh
+++ b/tests/update_conformance_schemas.sh
@@ -45,6 +45,18 @@ update_postman \
   "responseSchema200Identifiers" \
   "$(get_schema '.paths["/identifiers/{did}"].get.responses["200"].content["application/json"].schema')"
 
+# Identifiers [400]
+update_postman \
+"conformance_suite.postman_collection.json" \
+  "responseSchema400Identifiers" \
+  "$(get_schema '.paths["/identifiers/{did}"].get.responses["400"].content["application/json"].schema')"
+
+# Identifiers [404]
+update_postman \
+"conformance_suite.postman_collection.json" \
+  "responseSchema404" \
+  "$(get_schema '.paths["/identifiers/{did}"].get.responses["404"].content["application/json"].schema')"
+
 # Credentials - Issue [201]
 update_postman \
 "conformance_suite.postman_collection.json" \


### PR DESCRIPTION
This PR add a generic `404` error to the OpenAPI schema and to the set of responses for `/identifiers/:did`, as well as an endpoint-specific `400` error for `/identifiers/:did` with a custom message.

FIX: #289