### PR TITLE
fix: use proper RFC 6749 token request for tutorial tests

### DIFF
--- a/docs/tutorials/agility/agility.collection.json
+++ b/docs/tutorials/agility/agility.collection.json
@@ -28,13 +28,34 @@
 					}
 				],
 				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"audience\": \"{{TOKEN_AUDIENCE}}\",\n    \"client_id\": \"{{CLIENT_ID}}\",\n    \"client_secret\": \"{{CLIENT_SECRET}}\",\n    \"grant_type\": \"client_credentials\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "audience",
+							"value": "{{TOKEN_AUDIENCE}}",
+							"type": "text"
+						},
+						{
+							"key": "client_id",
+							"value": "{{CLIENT_ID}}",
+							"type": "text"
+						},
+						{
+							"key": "client_secret",
+							"value": "{{CLIENT_SECRET}}",
+							"type": "text"
+						},
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "resolve:dids issue:credentials",
+							"type": "text"
 						}
-					}
+					]
 				},
 				"url": {
 					"raw": "{{TOKEN_ENDPOINT}}",

--- a/docs/tutorials/authentication/authentication.postman_collection.json
+++ b/docs/tutorials/authentication/authentication.postman_collection.json
@@ -50,13 +50,29 @@
 				"method": "POST",
 				"header": [],
 				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"audience\": \"{{TOKEN_AUDIENCE}}\",\n    \"client_id\": \"{{CLIENT_ID}}\",\n    \"client_secret\": \"{{CLIENT_SECRET}}\",\n    \"grant_type\": \"client_credentials\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "audience",
+							"value": "{{TOKEN_AUDIENCE}}",
+							"type": "text"
+						},
+						{
+							"key": "client_id",
+							"value": "{{CLIENT_ID}}",
+							"type": "text"
+						},
+						{
+							"key": "client_secret",
+							"value": "{{CLIENT_SECRET}}",
+							"type": "text"
+						},
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
 						}
-					}
+					]
 				},
 				"url": {
 					"raw": "{{TOKEN_ENDPOINT}}",

--- a/docs/tutorials/credentials-issue/credentials-issue.postman_collection.json
+++ b/docs/tutorials/credentials-issue/credentials-issue.postman_collection.json
@@ -58,13 +58,34 @@
 				"method": "POST",
 				"header": [],
 				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"audience\": \"{{TOKEN_AUDIENCE}}\",\n    \"client_id\": \"{{CLIENT_ID}}\",\n    \"client_secret\": \"{{CLIENT_SECRET}}\",\n    \"grant_type\": \"client_credentials\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "audience",
+							"value": "{{TOKEN_AUDIENCE}}",
+							"type": "text"
+						},
+						{
+							"key": "client_id",
+							"value": "{{CLIENT_ID}}",
+							"type": "text"
+						},
+						{
+							"key": "client_secret",
+							"value": "{{CLIENT_SECRET}}",
+							"type": "text"
+						},
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "resolve:dids issue:credentials",
+							"type": "text"
 						}
-					}
+					]
 				},
 				"url": {
 					"raw": "{{TOKEN_ENDPOINT}}",

--- a/docs/tutorials/credentials-revocation/credentials-revocation.postman_collection.json
+++ b/docs/tutorials/credentials-revocation/credentials-revocation.postman_collection.json
@@ -59,13 +59,34 @@
 				"method": "POST",
 				"header": [],
 				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"audience\": \"{{TOKEN_AUDIENCE}}\",\n    \"client_id\": \"{{CLIENT_ID}}\",\n    \"client_secret\": \"{{CLIENT_SECRET}}\",\n    \"grant_type\": \"client_credentials\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "audience",
+							"value": "{{TOKEN_AUDIENCE}}",
+							"type": "text"
+						},
+						{
+							"key": "client_id",
+							"value": "{{CLIENT_ID}}",
+							"type": "text"
+						},
+						{
+							"key": "client_secret",
+							"value": "{{CLIENT_SECRET}}",
+							"type": "text"
+						},
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "resolve:dids issue:credentials verify:credentials update:credentials",
+							"type": "text"
 						}
-					}
+					]
 				},
 				"url": {
 					"raw": "{{TOKEN_ENDPOINT}}",

--- a/docs/tutorials/credentials-verify/credentials-verify.postman_collection.json
+++ b/docs/tutorials/credentials-verify/credentials-verify.postman_collection.json
@@ -1,350 +1,390 @@
 {
-  "info": {
-    "_postman_id": "48596ec9-acce-4014-8e0f-6fd7abcb4783",
-    "name": "Credentials Verify Tutorial",
-    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
-  },
-  "item": [
-    {
-      "name": "Get Access Token",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "// Token requests are expected to return a `200 Success` response code. Any",
-              "// other response code should trigger a failure.",
-              "pm.test(\"must return `200 Success` status\", function() {",
-              "    pm.response.to.have.status(200);",
-              "});",
-              "",
-              "// The response should include an `access_token` value - this will be presented",
-              "// to authenticated API endpoints in the `Authentication` header (see the last",
-              "// testing code block for details on how this is persisted).",
-              "pm.test(\"response body must include non-empty access_token\", function () {",
-              "    const { access_token } = pm.response.json()",
-              "    pm.expect(access_token).to.be.a('string').that.is.not.empty;",
-              "});",
-              "",
-              "// The type of `access_token` returned by the token request is expected to be",
-              "// `Bearer`.",
-              "pm.test(\"response body must represent `Bearer` token\", function() {",
-              "    const { token_type } = pm.response.json()",
-              "    pm.expect(token_type).to.equal(\"Bearer\");",
-              "});",
-              "",
-              "// The returned data includes an `expires_in` field that indicates time until",
-              "// token expiration. Validate that this value is a whole number greater than",
-              "// zero, as anything less than or equal to zero means that the `access_token`",
-              "// is already expired.",
-              "pm.test(\"returned token must expire in the future\", function() {",
-              "    const { expires_in } = pm.response.json()",
-              "    pm.expect(expires_in).to.be.above(0);",
-              "});",
-              "",
-              "// The returned `access_token` value is persisted as a Postman collection",
-              "// variable that can be accessed by other requests in the collection by calling",
-              "// `pm.collectionVariables.get(\"access_token\")`.",
-              "pm.test(\"`access_token` persisted to collectionVariables\", function() {",
-              "    const { access_token } = pm.response.json()",
-              "    pm.collectionVariables.set(\"access_token\", access_token);",
-              "});"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n    \"audience\": \"{{TOKEN_AUDIENCE}}\",\n    \"client_id\": \"{{CLIENT_ID}}\",\n    \"client_secret\": \"{{CLIENT_SECRET}}\",\n    \"grant_type\": \"client_credentials\"\n}",
-          "options": {
-            "raw": {
-              "language": "json"
-            }
-          }
-        },
-        "url": {
-          "raw": "{{TOKEN_ENDPOINT}}",
-          "host": ["{{TOKEN_ENDPOINT}}"]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "Get Organization DIDs",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "// This endpoint is authenticated. This test will not prevent the request from",
-              "// running when the `access_token` collection variable is missing, but it will",
-              "// give an indication of why the request failed in that scenario.",
-              "pm.test(\"`access_token` collection variable must be set\", function () {",
-              "    const access_token = pm.collectionVariables.get(\"access_token\");",
-              "    pm.expect(access_token).to.be.a('string').that.is.not.empty;",
-              "});",
-              "",
-              "pm.test(\"Status code is 200\", function () {",
-              "    pm.response.to.have.status(200);",
-              "});",
-              "",
-              "pm.test(\"must include valid JSON response body\", function() {",
-              "    pm.response.json(); // will throw on parse failure",
-              "});",
-              "",
-              "// The response JSON must include a didDocument property that contains the",
-              "// resolved DID document.",
-              "pm.test(\"didDocument must be present in response body\", function() {",
-              "    const jsonData = pm.response.json();",
-              "    pm.expect(jsonData).to.have.property('didDocument');",
-              "});",
-              "",
-              "// The DID document must contain an alsoKnownAs property.",
-              "pm.test(\"alsoKnownAs MUST be present\", function () {",
-              "    const { didDocument } = pm.response.json();",
-              "    pm.expect(didDocument).to.have.property('alsoKnownAs');",
-              "});",
-              "",
-              "// The alsoKnownAs property MUST be an array.",
-              "pm.test(\"alsoKnownAs MUST be an array\", function() {",
-              "    const { alsoKnownAs } = pm.response.json().didDocument;",
-              "    pm.expect(alsoKnownAs).to.be.an('array');",
-              "});",
-              "",
-              "// The alsoKnownAs property MUST be a set.",
-              "pm.test(\"alsoKnownAs values MUST be unique\", function() {",
-              "    const { alsoKnownAs } = pm.response.json().didDocument;",
-              "    pm.expect(new Set(alsoKnownAs)).to.have.lengthOf(alsoKnownAs.length);",
-              "});",
-              "",
-              "// The second element of the alsoKnownAs property will be used as a",
-              "// credentials_issuer_id for subsequent tests.",
-              "pm.test(\"alsoKnownAs[1] must be present\", function() {",
-              "    const { alsoKnownAs } = pm.response.json().didDocument;",
-              "    pm.expect(alsoKnownAs[1]).to.be.a('string').that.is.not.empty;",
-              "});",
-              "",
-              "// If a verificationMethod property is present, the controller property must",
-              "// match the didDocument.id property.",
-              "pm.test(\"verification method controller must match did subject\", function() {",
-              "    const { didDocument } = pm.response.json();",
-              "    const vm = didDocument.verificationMethod || [];",
-              "    vm.forEach((m) => pm.expect(m.controller).to.equal(didDocument.id));",
-              "});",
-              "",
-              "// The value of didDocument.alsoKnownAs[1] is persisted as a Postman collection",
-              "// variable that can be accessed by other requests in the collection by calling",
-              "// pm.collectionVariables.get(\"credential_issuer_id\").",
-              "pm.test(\"`credential_issuer_id` persisted to collectionVariables\", function() {",
-              "    const { alsoKnownAs } = pm.response.json().didDocument;",
-              "    pm.collectionVariables.set(\"credential_issuer_id\", alsoKnownAs[1]);",
-              "});"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "protocolProfileBehavior": {
-        "disabledSystemHeaders": {}
-      },
-      "request": {
-        "auth": {
-          "type": "bearer",
-          "bearer": [
-            {
-              "key": "token",
-              "value": "{{access_token}}",
-              "type": "string"
-            }
-          ]
-        },
-        "method": "GET",
-        "header": [
-          {
-            "key": "Accept",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "url": {
-          "raw": "{{API_BASE_URL}}/identifiers/{{ORGANIZATION_DID_WEB}}",
-          "host": ["{{API_BASE_URL}}"],
-          "path": ["identifiers", "{{ORGANIZATION_DID_WEB}}"]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "Issue Credential",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"`access_token` collection variable must be set\", function () {",
-              "    pm.expect(pm.collectionVariables.get(\"access_token\")).to.not.be.undefined;",
-              "});",
-              "",
-              "pm.test(\"`credential_issuer_id` collection variable must be set\", function () {",
-              "    pm.expect(pm.collectionVariables.get(\"credential_issuer_id\")).to.not.be.undefined;",
-              "});",
-              "",
-              "pm.test(\"must return `201 Created` status\", function () {",
-              "    pm.response.to.have.status(201);",
-              "});",
-              "",
-              "// Verifiable credential must be made available to later requests",
-              "pm.test(\"`verifiable_credential` persisted to collectionVariables\", function() {",
-              "    const verifiable_credential = JSON.stringify(pm.response.json());",
-              "    pm.collectionVariables.set(\"verifiable_credential\", verifiable_credential);",
-              "})",
-              ""
-            ],
-            "type": "text/javascript"
-          }
-        },
-        {
-          "listen": "prerequest",
-          "script": {
-            "exec": [""],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "auth": {
-          "type": "bearer",
-          "bearer": [
-            {
-              "key": "token",
-              "value": "{{access_token}}",
-              "type": "string"
-            }
-          ]
-        },
-        "method": "POST",
-        "header": [
-          {
-            "key": "Accept",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n    \"credential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"id\": \"urn:uuid:{{$randomUUID}}\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"issuer\": \"{{credential_issuer_id}}\",\n        \"issuanceDate\": \"2010-01-01T19:23:24Z\",\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        }\n    },\n    \"options\": {\n        \"type\": \"Ed25519Signature2018\",\n        \"created\": \"2020-04-02T18:48:36Z\"\n    }\n}",
-          "options": {
-            "raw": {
-              "language": "json"
-            }
-          }
-        },
-        "url": {
-          "raw": "{{API_BASE_URL}}/credentials/issue",
-          "host": ["{{API_BASE_URL}}"],
-          "path": ["credentials", "issue"]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "Verify Credential",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "// The `/credentials/verify` endpoint is authenticated. This test will not",
-              "// prevent the request from running when the `access_token` collection variable",
-              "// is missing, but it will give an indication of why the request failed in that",
-              "// scenario.",
-              "pm.test(\"`access_token` collection variable must be set\", function () {",
-              "    pm.expect(pm.collectionVariables.get(\"access_token\")).to.not.be.undefined;",
-              "});",
-              "",
-              "// The `verifiable_credential` from the \"Credentials Issue\" request is used to",
-              "// populate part of the request body. If this collection variable is missing,",
-              "// the request will not be prevented, but this test will raise an error that",
-              "// will help to identify the problem.",
-              "pm.test(\"`verifiable_credential` collection variable must be set\", function () {",
-              "    pm.expect(pm.collectionVariables.get(\"verifiable_credential\")).to.not.be.undefined;",
-              "});",
-              "",
-              "// The expected response code for a \"Credentials Verify\" request is",
-              "// `200 Success`.",
-              "pm.test(\"must return `200 Success` status\", function () {",
-              "    pm.response.to.have.status(200);",
-              "});",
-              "",
-              "",
-              "// The verification should succeed.",
-              "pm.test(\"verification should be successful\", function() {",
-              "    const { verified } = pm.response.json()",
-              "    pm.expect(verified).to.be.true;",
-              "});",
-              ""
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "auth": {
-          "type": "bearer",
-          "bearer": [
-            {
-              "key": "token",
-              "value": "{{access_token}}",
-              "type": "string"
-            }
-          ]
-        },
-        "method": "POST",
-        "header": [
-          {
-            "key": "Accept",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n    \"verifiableCredential\": {{verifiable_credential}}\n}",
-          "options": {
-            "raw": {
-              "language": "json"
-            }
-          }
-        },
-        "url": {
-          "raw": "{{API_BASE_URL}}/credentials/verify",
-          "host": ["{{API_BASE_URL}}"],
-          "path": ["credentials", "verify"]
-        }
-      },
-      "response": []
-    }
-  ],
-  "variable": [
-    {
-      "key": "foo",
-      "value": ""
-    },
-    {
-      "key": "credential_issuer_id",
-      "value": ""
-    },
-    {
-      "key": "access_token",
-      "value": ""
-    },
-    {
-      "key": "verifiable_credential",
-      "value": ""
-    }
-  ]
+	"info": {
+		"_postman_id": "48596ec9-acce-4014-8e0f-6fd7abcb4783",
+		"name": "Credentials Verify Tutorial",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Get Access Token",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"// Token requests are expected to return a `200 Success` response code. Any",
+							"// other response code should trigger a failure.",
+							"pm.test(\"must return `200 Success` status\", function() {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"// The response should include an `access_token` value - this will be presented",
+							"// to authenticated API endpoints in the `Authentication` header (see the last",
+							"// testing code block for details on how this is persisted).",
+							"pm.test(\"response body must include non-empty access_token\", function () {",
+							"    const { access_token } = pm.response.json()",
+							"    pm.expect(access_token).to.be.a('string').that.is.not.empty;",
+							"});",
+							"",
+							"// The type of `access_token` returned by the token request is expected to be",
+							"// `Bearer`.",
+							"pm.test(\"response body must represent `Bearer` token\", function() {",
+							"    const { token_type } = pm.response.json()",
+							"    pm.expect(token_type).to.equal(\"Bearer\");",
+							"});",
+							"",
+							"// The returned data includes an `expires_in` field that indicates time until",
+							"// token expiration. Validate that this value is a whole number greater than",
+							"// zero, as anything less than or equal to zero means that the `access_token`",
+							"// is already expired.",
+							"pm.test(\"returned token must expire in the future\", function() {",
+							"    const { expires_in } = pm.response.json()",
+							"    pm.expect(expires_in).to.be.above(0);",
+							"});",
+							"",
+							"// The returned `access_token` value is persisted as a Postman collection",
+							"// variable that can be accessed by other requests in the collection by calling",
+							"// `pm.collectionVariables.get(\"access_token\")`.",
+							"pm.test(\"`access_token` persisted to collectionVariables\", function() {",
+							"    const { access_token } = pm.response.json()",
+							"    pm.collectionVariables.set(\"access_token\", access_token);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "audience",
+							"value": "{{TOKEN_AUDIENCE}}",
+							"type": "text"
+						},
+						{
+							"key": "client_id",
+							"value": "{{CLIENT_ID}}",
+							"type": "text"
+						},
+						{
+							"key": "client_secret",
+							"value": "{{CLIENT_SECRET}}",
+							"type": "text"
+						},
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "resolve:dids issue:credentials verify:credentials",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "{{TOKEN_ENDPOINT}}",
+					"host": [
+						"{{TOKEN_ENDPOINT}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Organization DIDs",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"// This endpoint is authenticated. This test will not prevent the request from",
+							"// running when the `access_token` collection variable is missing, but it will",
+							"// give an indication of why the request failed in that scenario.",
+							"pm.test(\"`access_token` collection variable must be set\", function () {",
+							"    const access_token = pm.collectionVariables.get(\"access_token\");",
+							"    pm.expect(access_token).to.be.a('string').that.is.not.empty;",
+							"});",
+							"",
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"must include valid JSON response body\", function() {",
+							"    pm.response.json(); // will throw on parse failure",
+							"});",
+							"",
+							"// The response JSON must include a didDocument property that contains the",
+							"// resolved DID document.",
+							"pm.test(\"didDocument must be present in response body\", function() {",
+							"    const jsonData = pm.response.json();",
+							"    pm.expect(jsonData).to.have.property('didDocument');",
+							"});",
+							"",
+							"// The DID document must contain an alsoKnownAs property.",
+							"pm.test(\"alsoKnownAs MUST be present\", function () {",
+							"    const { didDocument } = pm.response.json();",
+							"    pm.expect(didDocument).to.have.property('alsoKnownAs');",
+							"});",
+							"",
+							"// The alsoKnownAs property MUST be an array.",
+							"pm.test(\"alsoKnownAs MUST be an array\", function() {",
+							"    const { alsoKnownAs } = pm.response.json().didDocument;",
+							"    pm.expect(alsoKnownAs).to.be.an('array');",
+							"});",
+							"",
+							"// The alsoKnownAs property MUST be a set.",
+							"pm.test(\"alsoKnownAs values MUST be unique\", function() {",
+							"    const { alsoKnownAs } = pm.response.json().didDocument;",
+							"    pm.expect(new Set(alsoKnownAs)).to.have.lengthOf(alsoKnownAs.length);",
+							"});",
+							"",
+							"// The second element of the alsoKnownAs property will be used as a",
+							"// credentials_issuer_id for subsequent tests.",
+							"pm.test(\"alsoKnownAs[1] must be present\", function() {",
+							"    const { alsoKnownAs } = pm.response.json().didDocument;",
+							"    pm.expect(alsoKnownAs[1]).to.be.a('string').that.is.not.empty;",
+							"});",
+							"",
+							"// If a verificationMethod property is present, the controller property must",
+							"// match the didDocument.id property.",
+							"pm.test(\"verification method controller must match did subject\", function() {",
+							"    const { didDocument } = pm.response.json();",
+							"    const vm = didDocument.verificationMethod || [];",
+							"    vm.forEach((m) => pm.expect(m.controller).to.equal(didDocument.id));",
+							"});",
+							"",
+							"// The value of didDocument.alsoKnownAs[1] is persisted as a Postman collection",
+							"// variable that can be accessed by other requests in the collection by calling",
+							"// pm.collectionVariables.get(\"credential_issuer_id\").",
+							"pm.test(\"`credential_issuer_id` persisted to collectionVariables\", function() {",
+							"    const { alsoKnownAs } = pm.response.json().didDocument;",
+							"    pm.collectionVariables.set(\"credential_issuer_id\", alsoKnownAs[1]);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {}
+			},
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{access_token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{API_BASE_URL}}/identifiers/{{ORGANIZATION_DID_WEB}}",
+					"host": [
+						"{{API_BASE_URL}}"
+					],
+					"path": [
+						"identifiers",
+						"{{ORGANIZATION_DID_WEB}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Issue Credential",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"`access_token` collection variable must be set\", function () {",
+							"    pm.expect(pm.collectionVariables.get(\"access_token\")).to.not.be.undefined;",
+							"});",
+							"",
+							"pm.test(\"`credential_issuer_id` collection variable must be set\", function () {",
+							"    pm.expect(pm.collectionVariables.get(\"credential_issuer_id\")).to.not.be.undefined;",
+							"});",
+							"",
+							"pm.test(\"must return `201 Created` status\", function () {",
+							"    pm.response.to.have.status(201);",
+							"});",
+							"",
+							"// Verifiable credential must be made available to later requests",
+							"pm.test(\"`verifiable_credential` persisted to collectionVariables\", function() {",
+							"    const verifiable_credential = JSON.stringify(pm.response.json());",
+							"    pm.collectionVariables.set(\"verifiable_credential\", verifiable_credential);",
+							"})",
+							""
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{access_token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"credential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"id\": \"urn:uuid:{{$randomUUID}}\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"issuer\": \"{{credential_issuer_id}}\",\n        \"issuanceDate\": \"2010-01-01T19:23:24Z\",\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        }\n    },\n    \"options\": {\n        \"type\": \"Ed25519Signature2018\",\n        \"created\": \"2020-04-02T18:48:36Z\"\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{API_BASE_URL}}/credentials/issue",
+					"host": [
+						"{{API_BASE_URL}}"
+					],
+					"path": [
+						"credentials",
+						"issue"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Verify Credential",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"// The `/credentials/verify` endpoint is authenticated. This test will not",
+							"// prevent the request from running when the `access_token` collection variable",
+							"// is missing, but it will give an indication of why the request failed in that",
+							"// scenario.",
+							"pm.test(\"`access_token` collection variable must be set\", function () {",
+							"    pm.expect(pm.collectionVariables.get(\"access_token\")).to.not.be.undefined;",
+							"});",
+							"",
+							"// The `verifiable_credential` from the \"Credentials Issue\" request is used to",
+							"// populate part of the request body. If this collection variable is missing,",
+							"// the request will not be prevented, but this test will raise an error that",
+							"// will help to identify the problem.",
+							"pm.test(\"`verifiable_credential` collection variable must be set\", function () {",
+							"    pm.expect(pm.collectionVariables.get(\"verifiable_credential\")).to.not.be.undefined;",
+							"});",
+							"",
+							"// The expected response code for a \"Credentials Verify\" request is",
+							"// `200 Success`.",
+							"pm.test(\"must return `200 Success` status\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"",
+							"// The verification should succeed.",
+							"pm.test(\"verification should be successful\", function() {",
+							"    const { verified } = pm.response.json()",
+							"    pm.expect(verified).to.be.true;",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{access_token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"verifiableCredential\": {{verifiable_credential}}\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{API_BASE_URL}}/credentials/verify",
+					"host": [
+						"{{API_BASE_URL}}"
+					],
+					"path": [
+						"credentials",
+						"verify"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"variable": [
+		{
+			"key": "foo",
+			"value": ""
+		},
+		{
+			"key": "credential_issuer_id",
+			"value": ""
+		},
+		{
+			"key": "access_token",
+			"value": ""
+		},
+		{
+			"key": "verifiable_credential",
+			"value": ""
+		}
+	]
 }

--- a/docs/tutorials/did-web-discovery/did-web-discovery.postman_collection.json
+++ b/docs/tutorials/did-web-discovery/did-web-discovery.postman_collection.json
@@ -58,13 +58,34 @@
 				"method": "POST",
 				"header": [],
 				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"audience\": \"{{TOKEN_AUDIENCE}}\",\n    \"client_id\": \"{{CLIENT_ID}}\",\n    \"client_secret\": \"{{CLIENT_SECRET}}\",\n    \"grant_type\": \"client_credentials\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "audience",
+							"value": "{{TOKEN_AUDIENCE}}",
+							"type": "text"
+						},
+						{
+							"key": "client_id",
+							"value": "{{CLIENT_ID}}",
+							"type": "text"
+						},
+						{
+							"key": "client_secret",
+							"value": "{{CLIENT_SECRET}}",
+							"type": "text"
+						},
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "resolve:dids",
+							"type": "text"
 						}
-					}
+					]
 				},
 				"url": {
 					"raw": "{{TOKEN_ENDPOINT}}",
@@ -182,6 +203,12 @@
 				}
 			},
 			"response": []
+		}
+	],
+	"variable": [
+		{
+			"key": "access_token",
+			"value": ""
 		}
 	]
 }

--- a/docs/tutorials/mill-test-report-certificate/vc-api.mtrc.collection.json
+++ b/docs/tutorials/mill-test-report-certificate/vc-api.mtrc.collection.json
@@ -28,13 +28,34 @@
 					}
 				],
 				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"audience\": \"{{TOKEN_AUDIENCE}}\",\n    \"client_id\": \"{{CLIENT_ID}}\",\n    \"client_secret\": \"{{CLIENT_SECRET}}\",\n    \"grant_type\": \"client_credentials\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "audience",
+							"value": "{{TOKEN_AUDIENCE}}",
+							"type": "text"
+						},
+						{
+							"key": "client_id",
+							"value": "{{CLIENT_ID}}",
+							"type": "text"
+						},
+						{
+							"key": "client_secret",
+							"value": "{{CLIENT_SECRET}}",
+							"type": "text"
+						},
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "resolve:dids issue:credentials verify:credentials",
+							"type": "text"
 						}
-					}
+					]
 				},
 				"url": {
 					"raw": "{{TOKEN_ENDPOINT}}",

--- a/docs/tutorials/presentations-exchange-oauth/presentations-exchange-oauth.json
+++ b/docs/tutorials/presentations-exchange-oauth/presentations-exchange-oauth.json
@@ -62,13 +62,34 @@
 				"method": "POST",
 				"header": [],
 				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"audience\": \"{{VERIFIER_TOKEN_AUDIENCE}}\",\n    \"client_id\": \"{{VERIFIER_CLIENT_ID}}\",\n    \"client_secret\": \"{{VERIFIER_CLIENT_SECRET}}\",\n    \"grant_type\": \"client_credentials\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "audience",
+							"value": "{{VERIFIER_TOKEN_AUDIENCE}}",
+							"type": "text"
+						},
+						{
+							"key": "client_id",
+							"value": "{{VERIFIER_CLIENT_ID}}",
+							"type": "text"
+						},
+						{
+							"key": "client_secret",
+							"value": "{{VERIFIER_CLIENT_SECRET}}",
+							"type": "text"
+						},
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "resolve:dids submit:presentations",
+							"type": "text"
 						}
-					}
+					]
 				},
 				"url": {
 					"raw": "{{VERIFIER_TOKEN_ENDPOINT}}",

--- a/docs/tutorials/presentations-exchange/presentations-exchange.postman_collection.json
+++ b/docs/tutorials/presentations-exchange/presentations-exchange.postman_collection.json
@@ -62,13 +62,34 @@
 				"method": "POST",
 				"header": [],
 				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"audience\": \"{{ISSUER_TOKEN_AUDIENCE}}\",\n    \"client_id\": \"{{ISSUER_CLIENT_ID}}\",\n    \"client_secret\": \"{{ISSUER_CLIENT_SECRET}}\",\n    \"grant_type\": \"client_credentials\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "audience",
+							"value": "{{ISSUER_TOKEN_AUDIENCE}}",
+							"type": "text"
+						},
+						{
+							"key": "client_id",
+							"value": "{{ISSUER_CLIENT_ID}}",
+							"type": "text"
+						},
+						{
+							"key": "client_secret",
+							"value": "{{ISSUER_CLIENT_SECRET}}",
+							"type": "text"
+						},
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "resolve:dids issue:credentials prove:presentations",
+							"type": "text"
 						}
-					}
+					]
 				},
 				"url": {
 					"raw": "{{ISSUER_TOKEN_ENDPOINT}}",
@@ -135,13 +156,34 @@
 				"method": "POST",
 				"header": [],
 				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"audience\": \"{{VERIFIER_TOKEN_AUDIENCE}}\",\n    \"client_id\": \"{{VERIFIER_CLIENT_ID}}\",\n    \"client_secret\": \"{{VERIFIER_CLIENT_SECRET}}\",\n    \"grant_type\": \"client_credentials\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "audience",
+							"value": "{{VERIFIER_TOKEN_AUDIENCE}}",
+							"type": "text"
+						},
+						{
+							"key": "client_id",
+							"value": "{{VERIFIER_CLIENT_ID}}",
+							"type": "text"
+						},
+						{
+							"key": "client_secret",
+							"value": "{{VERIFIER_CLIENT_SECRET}}",
+							"type": "text"
+						},
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "resolve:dids",
+							"type": "text"
 						}
-					}
+					]
 				},
 				"url": {
 					"raw": "{{VERIFIER_TOKEN_ENDPOINT}}",

--- a/docs/tutorials/presentations-verify/presentations-verify.postman_collection.json
+++ b/docs/tutorials/presentations-verify/presentations-verify.postman_collection.json
@@ -62,13 +62,34 @@
 				"method": "POST",
 				"header": [],
 				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"audience\": \"{{ISSUER_TOKEN_AUDIENCE}}\",\n    \"client_id\": \"{{ISSUER_CLIENT_ID}}\",\n    \"client_secret\": \"{{ISSUER_CLIENT_SECRET}}\",\n    \"grant_type\": \"client_credentials\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "audience",
+							"value": "{{ISSUER_TOKEN_AUDIENCE}}",
+							"type": "text"
+						},
+						{
+							"key": "client_id",
+							"value": "{{ISSUER_CLIENT_ID}}",
+							"type": "text"
+						},
+						{
+							"key": "client_secret",
+							"value": "{{ISSUER_CLIENT_SECRET}}",
+							"type": "text"
+						},
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "resolve:dids issue:credentials prove:presentations",
+							"type": "text"
 						}
-					}
+					]
 				},
 				"url": {
 					"raw": "{{ISSUER_TOKEN_ENDPOINT}}",
@@ -135,13 +156,34 @@
 				"method": "POST",
 				"header": [],
 				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"audience\": \"{{VERIFIER_TOKEN_AUDIENCE}}\",\n    \"client_id\": \"{{VERIFIER_CLIENT_ID}}\",\n    \"client_secret\": \"{{VERIFIER_CLIENT_SECRET}}\",\n    \"grant_type\": \"client_credentials\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "audience",
+							"value": "{{VERIFIER_TOKEN_AUDIENCE}}",
+							"type": "text"
+						},
+						{
+							"key": "client_id",
+							"value": "{{VERIFIER_CLIENT_ID}}",
+							"type": "text"
+						},
+						{
+							"key": "client_secret",
+							"value": "{{VERIFIER_CLIENT_SECRET}}",
+							"type": "text"
+						},
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "resolve:dids verify:presentations",
+							"type": "text"
 						}
-					}
+					]
 				},
 				"url": {
 					"raw": "{{VERIFIER_TOKEN_ENDPOINT}}",
@@ -793,6 +835,18 @@
 		},
 		{
 			"key": "exchange_endpoint",
+			"value": ""
+		},
+		{
+			"key": "issuer_access_token",
+			"value": ""
+		},
+		{
+			"key": "verifier_access_token",
+			"value": ""
+		},
+		{
+			"key": "verifier_exchange_endpoint",
 			"value": ""
 		}
 	]

--- a/docs/tutorials/vc-jwt/vc-jwt.collection.json
+++ b/docs/tutorials/vc-jwt/vc-jwt.collection.json
@@ -28,13 +28,34 @@
 					}
 				],
 				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"audience\": \"{{TOKEN_AUDIENCE}}\",\n    \"client_id\": \"{{CLIENT_ID}}\",\n    \"client_secret\": \"{{CLIENT_SECRET}}\",\n    \"grant_type\": \"client_credentials\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "audience",
+							"value": "{{TOKEN_AUDIENCE}}",
+							"type": "text"
+						},
+						{
+							"key": "client_id",
+							"value": "{{CLIENT_ID}}",
+							"type": "text"
+						},
+						{
+							"key": "client_secret",
+							"value": "{{CLIENT_SECRET}}",
+							"type": "text"
+						},
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "resolve:dids issue:credentials verify:credentials",
+							"type": "text"
 						}
-					}
+					]
 				},
 				"url": {
 					"raw": "{{TOKEN_ENDPOINT}}",

--- a/docs/tutorials/workflow-join/workflow-instance-join.collection.json
+++ b/docs/tutorials/workflow-join/workflow-instance-join.collection.json
@@ -40,13 +40,34 @@
 					}
 				],
 				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"audience\": \"{{ORG_1_TOKEN_AUDIENCE}}\",\n    \"client_id\": \"{{ORG_1_CLIENT_ID}}\",\n    \"client_secret\": \"{{ORG_1_CLIENT_SECRET}}\",\n    \"grant_type\": \"client_credentials\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "audience",
+							"value": "{{ORG_1_TOKEN_AUDIENCE}}",
+							"type": "text"
+						},
+						{
+							"key": "client_id",
+							"value": "{{ORG_1_CLIENT_ID}}",
+							"type": "text"
+						},
+						{
+							"key": "client_secret",
+							"value": "{{ORG_1_CLIENT_SECRET}}",
+							"type": "text"
+						},
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "resolve:dids issue:credentials prove:presentations verify:presentations",
+							"type": "text"
 						}
-					}
+					]
 				},
 				"url": {
 					"raw": "{{ORG_1_TOKEN_ENDPOINT}}",
@@ -92,13 +113,34 @@
 					}
 				],
 				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"audience\": \"{{ORG_2_TOKEN_AUDIENCE}}\",\n    \"client_id\": \"{{ORG_2_CLIENT_ID}}\",\n    \"client_secret\": \"{{ORG_2_CLIENT_SECRET}}\",\n    \"grant_type\": \"client_credentials\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "audience",
+							"value": "{{ORG_2_TOKEN_AUDIENCE}}",
+							"type": "text"
+						},
+						{
+							"key": "client_id",
+							"value": "{{ORG_2_CLIENT_ID}}",
+							"type": "text"
+						},
+						{
+							"key": "client_secret",
+							"value": "{{ORG_2_CLIENT_SECRET}}",
+							"type": "text"
+						},
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "resolve:dids issue:credentials prove:presentations verify:presentations",
+							"type": "text"
 						}
-					}
+					]
 				},
 				"url": {
 					"raw": "{{ORG_2_TOKEN_ENDPOINT}}",
@@ -144,13 +186,34 @@
 					}
 				],
 				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"audience\": \"{{ORG_3_TOKEN_AUDIENCE}}\",\n    \"client_id\": \"{{ORG_3_CLIENT_ID}}\",\n    \"client_secret\": \"{{ORG_3_CLIENT_SECRET}}\",\n    \"grant_type\": \"client_credentials\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "audience",
+							"value": "{{ORG_3_TOKEN_AUDIENCE}}",
+							"type": "text"
+						},
+						{
+							"key": "client_id",
+							"value": "{{ORG_3_CLIENT_ID}}",
+							"type": "text"
+						},
+						{
+							"key": "client_secret",
+							"value": "{{ORG_3_CLIENT_SECRET}}",
+							"type": "text"
+						},
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "resolve:dids issue:credentials prove:presentations verify:presentations",
+							"type": "text"
 						}
-					}
+					]
 				},
 				"url": {
 					"raw": "{{ORG_3_TOKEN_ENDPOINT}}",


### PR DESCRIPTION
This pull request updates existing Postman interoperability tutorial suites to use proper RFC 6749 token requests (#350) and adds the required scopes to the request (#356)