### PR TITLE
feat: begin publishing archived reports

### DIFF
--- a/.github/workflows/conformance-run.yml
+++ b/.github/workflows/conformance-run.yml
@@ -147,10 +147,26 @@ jobs:
           name: reports
           path: docs/reports/
 
-      # Publish reports subfolder to GitHub Pages
+      # Publish report subfolder to GitHub Pages
       - name: Publish Conformance Report
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/reports
           destination_dir: reports/conformance
+
+      # Prepare an archive folder name and update the index.json appropriately
+      - name: Prepare Conformance Archive
+        id: archive
+        run: |
+          FOLDER=conformance-$(date +'%s')
+          sed -i "s#reports/conformance/#reports/$FOLDER/#" ./docs/reports/index.json
+          echo "::set-output name=folder::$FOLDER"
+
+      # Publish report archive subfolder to GitHub Pages
+      - name: Publish Conformance Archive
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/reports
+          destination_dir: reports/${{ steps.archive.outputs.folder }}

--- a/.github/workflows/interoperability-report.yml
+++ b/.github/workflows/interoperability-report.yml
@@ -645,10 +645,26 @@ jobs:
         working-directory: ./reporting
         run: ./reporter.py --mode ci --interoperability
 
-      # Publish reports subfolder to GitHub Pages
-      - name: Publish Reports
+      # Publish report subfolder to GitHub Pages
+      - name: Publish Interoperability Report
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/reports
           destination_dir: reports/interoperability
+
+      # Prepare an archive folder name and update the index.json appropriately
+      - name: Prepare Interoperability Archive
+        id: archive
+        run: |
+          FOLDER=interoperability-$(date +'%s')
+          sed -i "s#reports/interoperability/#reports/$FOLDER/#" ./docs/reports/index.json
+          echo "::set-output name=folder::$FOLDER"
+
+      # Publish report archive subfolder to GitHub Pages
+      - name: Publish Interoperability Archive
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/reports
+          destination_dir: reports/${{ steps.archive.outputs.folder }}


### PR DESCRIPTION
This PR modifies existing GitHub workflows that publish nightly reports to add a step that stores the reports in a timestamped folder for archival purposes.

Conformance and Interoperability reports continue to be published to the `reports/conformance` and `reports/interoperability` GitHub pages subfolders respectively, and are now also published to `reports/conformance-XXXXXXXXXX` and `reports/interoperability-XXXXXXXXXX` subfolders (where XXXXXXXXXX is the current unix epoch timestamp at the time of publishing).

This PR addresses long-term storage of the nightly scheduled reports, but it does NOT generate a browsable index. That work will still need to be completed, possibly in a separate ticket.

REF: #199