### PR TITLE
chore: clarify request body for credentials status request

### DIFF
--- a/docs/openapi/resources/credential-status.yml
+++ b/docs/openapi/resources/credential-status.yml
@@ -36,7 +36,7 @@ post:
                     # Traceability interoperability implementation must conform
                     # with VC-API, which uses string for the status property.
                     # https://w3c-ccg.github.io/vc-api/#update-status
-                    description: Use a string value of "0" (zero) to indicate "revoked", or "1" (one) to indicate not revoked.
+                    description: Use a string value of "1" (one) to indicate "revoked", or "0" (zero) to indicate not revoked.
                     type: string
                     enum: ['0', '1']
           example: {

--- a/docs/openapi/resources/credential-status.yml
+++ b/docs/openapi/resources/credential-status.yml
@@ -14,25 +14,35 @@ post:
         schema:
           type: object
           description: Request for updating the status of an issued credential.
+          required:
+            - credentialId
+            - credentialStatus
           properties:
-            # Only credentials with an id are revocable.
             credentialId:
               type: string
             credentialStatus:
               type: array
+              maxItems: 1
               items:
                 type: object
+                required:
+                  - type
+                  - status
                 properties:
                   type:
                     type: string
+                    enum: ['RevocationList2020Status']
                   status:
-                    type: string
+                    description: Use a value of 0 (zero) to indicate "revoked", or 1 (one) to indicate not revoked.
+                    type: integer
+                    minimum: 0
+                    maximum: 1
           example: {
               'credentialId': 'urn:uuid:45a44711-e457-4fa8-9b89-69fe0287c86a',
               # // https://w3c-ccg.github.io/vc-status-rl-2020/
               # // If the binary value of the position in the list is 1 (one),
               # // the verifiable credential is revoked, if it is 0 (zero) it is not revoked.
-              'credentialStatus': [{ 'type': 'RevocationList2020Status', 'status': '0' }],
+              'credentialStatus': [{ 'type': 'RevocationList2020Status', 'status': 0 }],
             }
   responses:
     '200':

--- a/docs/openapi/resources/credential-status.yml
+++ b/docs/openapi/resources/credential-status.yml
@@ -33,16 +33,18 @@ post:
                     type: string
                     enum: ['RevocationList2020Status']
                   status:
-                    description: Use a value of 0 (zero) to indicate "revoked", or 1 (one) to indicate not revoked.
-                    type: integer
-                    minimum: 0
-                    maximum: 1
+                    # Traceability interoperability implementation must conform
+                    # with VC-API, which uses string for the status property.
+                    # https://w3c-ccg.github.io/vc-api/#update-status
+                    description: Use a string value of "0" (zero) to indicate "revoked", or "1" (one) to indicate not revoked.
+                    type: string
+                    enum: ['0', '1']
           example: {
               'credentialId': 'urn:uuid:45a44711-e457-4fa8-9b89-69fe0287c86a',
               # // https://w3c-ccg.github.io/vc-status-rl-2020/
               # // If the binary value of the position in the list is 1 (one),
               # // the verifiable credential is revoked, if it is 0 (zero) it is not revoked.
-              'credentialStatus': [{ 'type': 'RevocationList2020Status', 'status': 0 }],
+              'credentialStatus': [{ 'type': 'RevocationList2020Status', 'status': '0' }],
             }
   responses:
     '200':


### PR DESCRIPTION
This PR is an implementation of the proposed changes from #358, namely making the OpenAPI definition for `credentials/status` request bodies more strict.

fixes #358 