### PR TITLE
Removing code and message from responseSchema40x schemas

### DIFF
--- a/docs/openapi/schemas/Error.yml
+++ b/docs/openapi/schemas/Error.yml
@@ -1,11 +1,7 @@
 type: object
 required:
-  - code
   - message
 properties:
-  code:
-    type: integer
-    format: int32
   message:
     type: string
   details:

--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -4630,22 +4630,22 @@
 		},
 		{
 			"key": "responseSchema400",
-			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}]}",
+			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"code\":{\"enum\":[400]},\"message\":{\"enum\":[\"Bad Request: Your request body does not conform to the required schema\"]}}}]}",
 			"type": "string"
 		},
 		{
 			"key": "responseSchema401",
-			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}]}",
+			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"code\":{\"enum\":[401]},\"message\":{\"enum\":[\"Unauthorized: This endpoint requires an OAuth2 bearer token\"]}}}]}",
 			"type": "string"
 		},
 		{
 			"key": "responseSchema403",
-			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}]}",
+			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"code\":{\"enum\":[403]},\"message\":{\"enum\":[\"Forbidden: OAuth2 bearer token does not have the required scope\"]}}}]}",
 			"type": "string"
 		},
 		{
 			"key": "responseSchema404",
-			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}]}",
+			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"code\":{\"enum\":[404]},\"message\":{\"enum\":[\"Not Found: The requested resource could not be found\"]}}}]}",
 			"type": "string"
 		},
 		{
@@ -4660,7 +4660,7 @@
 		},
 		{
 			"key": "responseSchema400Identifiers",
-			"value": "{\"allOf\":[{\"description\":\"Bad Request\",\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"type\":\"object\",\"required\":[\"code\",\"message\"],\"properties\":{\"code\":{\"type\":\"integer\"},\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"code\":{\"enum\":[400]},\"message\":{\"enum\":[\"Bad Request: Your request body does not conform to the required schema\"]}}}]}}}},{\"type\":\"object\",\"properties\":{\"message\":{\"enum\":[\"Bad Request: Invalid DID\"]}}}]}",
+			"value": "{\"allOf\":[{\"description\":\"Bad Request\",\"content\":{\"application/json\":{\"schema\":{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"code\":{\"enum\":[400]},\"message\":{\"enum\":[\"Bad Request: Your request body does not conform to the required schema\"]}}}]}}}},{\"type\":\"object\",\"properties\":{\"message\":{\"enum\":[\"Bad Request: Invalid DID\"]}}}]}",
 			"type": "string"
 		},
 		{

--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -4398,27 +4398,27 @@
 		},
 		{
 			"key": "responseSchema400",
-			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"code\",\"message\"],\"properties\":{\"code\":{\"type\":\"integer\"},\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"code\":{\"enum\":[400]},\"message\":{\"enum\":[\"Bad Request: Your request body does not conform to the required schema\"]}}}]}",
+			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}]}",
 			"type": "string"
 		},
 		{
 			"key": "responseSchema401",
-			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"code\",\"message\"],\"properties\":{\"code\":{\"type\":\"integer\"},\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"code\":{\"enum\":[401]},\"message\":{\"enum\":[\"Unauthorized: This endpoint requires an OAuth2 bearer token\"]}}}]}",
+			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}]}",
 			"type": "string"
 		},
 		{
 			"key": "responseSchema403",
-			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"code\",\"message\"],\"properties\":{\"code\":{\"type\":\"integer\"},\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"code\":{\"enum\":[403]},\"message\":{\"enum\":[\"Forbidden: OAuth2 bearer token does not have the required scope\"]}}}]}",
+			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}]}",
 			"type": "string"
 		},
 		{
 			"key": "responseSchema404",
-			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"code\",\"message\"],\"properties\":{\"code\":{\"type\":\"integer\"},\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"code\":{\"enum\":[404]},\"message\":{\"enum\":[\"Not Found: The requested resource could not be found\"]}}}]}",
+			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}]}",
 			"type": "string"
 		},
 		{
 			"key": "responseSchema500",
-			"value": "{\"type\":\"object\",\"required\":[\"code\",\"message\"],\"properties\":{\"code\":{\"type\":\"integer\"},\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}",
+			"value": "{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}",
 			"type": "string"
 		},
 		{


### PR DESCRIPTION
This removes some of the asserted details from the responseSchema40x schemas: 
- `code` which seems redundant with the actual status code (see https://github.com/w3c-ccg/traceability-interop/issues/381).
- the precise error message, which is also redundant as it just describes the generic error http error.