### PR TITLE
fix: required verifiableCredential property in credentials/verify

### DIFF
--- a/docs/openapi/resources/credential-verifier.yml
+++ b/docs/openapi/resources/credential-verifier.yml
@@ -15,6 +15,8 @@ post:
       application/json:
         schema:
           type: object
+          required:
+            - verifiableCredential
           properties:
             verifiableCredential:
               $ref: "../schemas/SerializedVerifiableCredential.yml"


### PR DESCRIPTION
This PR implements the changes discussed in #360 to make the `verifiableCredential` property a required part of the `/credentials/verify` request body. Previously, this was an optional property.

Fixes #360 