### PR TITLE
chore: change response code for /credential/status

### DIFF
--- a/docs/openapi/resources/credential-status.yml
+++ b/docs/openapi/resources/credential-status.yml
@@ -47,7 +47,7 @@ post:
               'credentialStatus': [{ 'type': 'RevocationList2020Status', 'status': '0' }],
             }
   responses:
-    '200':
+    '204':
       description: Credential status successfully updated
     '400':
       description: Bad Request


### PR DESCRIPTION
This PR modifies the "success" response code for a `/credential/status` from `200` to `204`, per the discussion in #347.

Fixes #347 