### PR TITLE
fix: update credential subject positive test

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -2717,7 +2717,7 @@
 											"",
 											"pm.test(\"response credentialSubject matches request credential.credentialSubject\", function() {",
 											" const { credentialSubject } = pm.response.json();",
-											" pm.expect(credentialSubject).to.equal(pm.variables.get(\"credential_subject\"))",
+											" pm.expect(credentialSubject).to.be.empty;",
 											"});",
 											"",
 											"pm.test(\"response issuanceDate matches request credential.issuanceDate\", function() {",
@@ -2918,73 +2918,6 @@
 							"response": []
 						},
 						{
-							"name": "credentials_issue:credential:alt.credentialSubject.object",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"pm.test(\"status code is 201\", function () {",
-											" pm.response.to.have.status(201);",
-											"});",
-											"",
-											"pm.test(\"response validates against schema\", function() {",
-											" const schemaString = pm.collectionVariables.get(\"responseSchema201CredentialsIssue\");",
-											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
-											"});",
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"exec": [
-											"let rawBody = pm.variables.get(\"rawBody\");",
-											"",
-											"// credential.credentialSubject can be an object with optional 'id' element.",
-											"rawBody.credential.credentialSubject = {};",
-											"",
-											"// Request body must be serialized before sending over the wire.",
-											"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Accept",
-										"value": "application/json",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{requestBody}}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{API_BASE_URL}}/credentials/issue",
-									"host": [
-										"{{API_BASE_URL}}"
-									],
-									"path": [
-										"credentials",
-										"issue"
-									]
-								}
-							},
-							"response": []
-						},
-						{
 							"name": "credentials_issue:credential:alt.credentialSubject.object:opt.id",
 							"event": [
 								{
@@ -3000,15 +2933,11 @@
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 											"});",
 											"",
-											"pm.test(\"response credentialSubject matches request credential.credentialSubject.id\", function() {",
+											"pm.test(\"response credentialSubject.id matches request credential.credentialSubject.id\", function() {",
 											" const { credentialSubject } = pm.response.json();",
-											" // Implementations may reduce object with just \"id\" property to a bare string",
-											" if (typeof credentialSubject === 'string') {",
-											"  pm.expect(credentialSubject).to.equal(pm.variables.get(\"credential_subject\"))",
-											" } else {",
-											"  pm.expect(credentialSubject.id).to.equal(pm.variables.get(\"credential_subject\"))",
-											" }",
-											"});"
+											" pm.expect(credentialSubject.id).to.equal(pm.variables.get(\"credential_subject\"))",
+											"});",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -3316,9 +3245,7 @@
 							"        ],",
 							"        \"issuer\": \"{{credential_issuer_id}}\",",
 							"        \"issuanceDate\": \"{{issuance_date}}\",",
-							"        \"credentialSubject\": {",
-							"            \"id\": \"{{credential_subject}}\"",
-							"        }",
+							"        \"credentialSubject\": {}",
 							"    },",
 							"    \"options\": {",
 							"        \"type\": \"Ed25519Signature2018\",",


### PR DESCRIPTION
Update the `credentialSubject` positive test for `/credentials/issue` to take into account the required object-with-optional-id format.

Fixes #393 