### PR TITLE
chore: require type property for credentialStatus

### DIFF
--- a/docs/openapi/schemas/IssueCredentialOptions.yml
+++ b/docs/openapi/schemas/IssueCredentialOptions.yml
@@ -14,6 +14,8 @@ properties:
   credentialStatus:
     type: object
     description: The method of credential status.
+    required:
+      - type
     properties:
       type:
         type: string

--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -2365,6 +2365,74 @@
 									"response": []
 								},
 								{
+									"name": "credentials_issue:options.credentialStatus.type:missing",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"let rawBody = pm.variables.get(\"rawBody\");",
+													"",
+													"// options.credentialStatus must contain \"type\" when present",
+													"rawBody.options.credentialStatus = {};",
+													"",
+													"// Request body must be serialized before sending over the wire.",
+													"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/issue",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"issue"
+											]
+										}
+									},
+									"response": []
+								},
+								{
 									"name": "credentials_issue:options.credentialStatus.type:wrong_type",
 									"event": [
 										{
@@ -3154,73 +3222,6 @@
 											"let rawBody = pm.variables.get(\"rawBody\");",
 											"",
 											"// options.credentialStatus can be an optional object",
-											"rawBody.options.credentialStatus = {};",
-											"",
-											"// Request body must be serialized before sending over the wire.",
-											"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Accept",
-										"value": "application/json",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{{requestBody}}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{API_BASE_URL}}/credentials/issue",
-									"host": [
-										"{{API_BASE_URL}}"
-									],
-									"path": [
-										"credentials",
-										"issue"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "credentials_issue:options:opt.credentialStatus.type",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"pm.test(\"status code is 201\", function () {",
-											" pm.response.to.have.status(201);",
-											"});",
-											"",
-											"pm.test(\"response validates against schema\", function() {",
-											" const schemaString = pm.collectionVariables.get(\"responseSchema201CredentialsIssue\");",
-											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
-											"});",
-											""
-										],
-										"type": "text/javascript"
-									}
-								},
-								{
-									"listen": "prerequest",
-									"script": {
-										"exec": [
-											"let rawBody = pm.variables.get(\"rawBody\");",
-											"",
-											"// options.credentialStatus.type can specific string",
 											"rawBody.options.credentialStatus = {\"type\": \"RevocationList2020Status\"};",
 											"",
 											"// Request body must be serialized before sending over the wire.",


### PR DESCRIPTION
This PR makes the `credentialStatus.type` property required (when `credentialStatus` is present) in the `options` object when posting to `/credentials/issue`.

This change is driven by the vc-api specification as outlined in #395 

Fixes #395 