### PR TITLE
docs: remove alsoKnownAs references from respec

### DIFF
--- a/docs/spec/sections/use-case-requirements.html
+++ b/docs/spec/sections/use-case-requirements.html
@@ -210,11 +210,6 @@ See <a href="https://www.w3.org/TR/did-core/#authentication">authentication</a>.
       "https://w3id.org/traceability/v1"
     ],
     "id": "did:web:platform.example:organization:123",
-    "alsoKnownAs": [
-      "https://platform.example/organization/123",
-      "did:key:z6MksSdhqJH3VvzcX8WP6VbdB85e6T7aaL5yLLYeJLJrto8V",
-      "did:key:z82LkpR3sPw87xdgs72J3EzGXChciBmhV6ukkbeAGFtCpauXHiEwtM2tyDcphRnLmKsB1fi"
-    ],
     "assertionMethod": [
       "did:key:z6MksSdhqJH3VvzcX8WP6VbdB85e6T7aaL5yLLYeJLJrto8V#z6MksSdhqJH3VvzcX8WP6VbdB85e6T7aaL5yLLYeJLJrto8V",
       "did:key:z82LkpR3sPw87xdgs72J3EzGXChciBmhV6ukkbeAGFtCpauXHiEwtM2tyDcphRnLmKsB1fi#z82LkpR3sPw87xdgs72J3EzGXChciBmhV6ukkbeAGFtCpauXHiEwtM2tyDcphRnLmKsB1fi"


### PR DESCRIPTION
This PR removes references to alsoKnownAs from the respec doc in this repo.

References #389