### PR TITLE
fix: sync did schemas for service type property

### DIFF
--- a/docs/openapi/schemas/DidResolutionResponse.yml
+++ b/docs/openapi/schemas/DidResolutionResponse.yml
@@ -17,7 +17,9 @@ properties:
             - serviceEndpoint
           properties:
             type:
-              type: string
+              type: array
+              items:
+                type: string
             serviceEndpoint:
               type: string
   didResolutionMetadata:

--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -9026,7 +9026,7 @@
 		},
 		{
 			"key": "responseSchema200Identifiers",
-			"value": "{\"type\":\"object\",\"required\":[\"didDocument\"],\"properties\":{\"didDocument\":{\"type\":\"object\",\"required\":[\"service\"],\"properties\":{\"service\":{\"type\":\"array\",\"minItems\":1,\"items\":{\"type\":\"object\",\"required\":[\"type\",\"serviceEndpoint\"],\"properties\":{\"type\":{\"type\":\"string\"},\"serviceEndpoint\":{\"type\":\"string\"}}}}}},\"didResolutionMetadata\":{\"type\":\"object\"},\"didDocumentMetadata\":{\"type\":\"object\"}}}",
+			"value": "{\"type\":\"object\",\"required\":[\"didDocument\"],\"properties\":{\"didDocument\":{\"type\":\"object\",\"required\":[\"service\"],\"properties\":{\"service\":{\"type\":\"array\",\"minItems\":1,\"items\":{\"type\":\"object\",\"required\":[\"type\",\"serviceEndpoint\"],\"properties\":{\"type\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"serviceEndpoint\":{\"type\":\"string\"}}}}}},\"didResolutionMetadata\":{\"type\":\"object\"},\"didDocumentMetadata\":{\"type\":\"object\"}}}",
 			"type": "string"
 		},
 		{


### PR DESCRIPTION
This PR ensures that the schemas related to DID documents are in sync with respect to the `type` property of `service` items, i.e., they must be array of string.

Fixes #408 
References #380 