### PR TITLE
did.json path determination from ORGANIZATION_DID_WEB

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "691a6d66-244e-4521-a0e5-6768dd6cf6f4",
+		"_postman_id": "802393fe-c7f8-48fc-93a3-85372c78d9c8",
 		"name": "Conformance Suite",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "4338127"
+		"_exporter_id": "15641111"
 	},
 	"item": [
 		{
@@ -31,18 +31,43 @@
 										],
 										"type": "text/javascript"
 									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const convertDidToEndpoint = (did) => {",
+											"  const regex = new RegExp(",
+											"    `did:web:(?<host>[a-zA-Z0-9/.\\\\-_]+)(:*)(?<port>[0-9]+)*(:*)(?<path>[a-zA-Z0-9/.:\\\\-_]*)`",
+											"  );",
+											"  const match = did.match(regex);",
+											"  if (!match) {",
+											"    throw new Error(\"DID is not a valid did:web\");",
+											"  }",
+											"  const { host, port, path } = match.groups;",
+											"  const origin = port ? `${host}:${port}` : `${host}`;",
+											"  const protocol = host.includes(\"localhost\") ? \"http\" : \"https\";",
+											"  const decodedPartialPath = path.split(\":\").join(\"/\");",
+											"  const endpoint = path",
+											"    ? `${protocol}://${origin}/${decodedPartialPath}/did.json`",
+											"    : `${protocol}://${origin}/.well-known/did.json`;",
+											"  return endpoint;",
+											"};",
+											"",
+											"const url =  convertDidToEndpoint(pm.environment.get(\"ORGANIZATION_DID_WEB\"))",
+											"pm.variables.set(\"did_doc_url\", url);"
+										],
+										"type": "text/javascript"
+									}
 								}
 							],
 							"request": {
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{API_BASE_URL}}/did.json",
+									"raw": "{{did_doc_url}}",
 									"host": [
-										"{{API_BASE_URL}}"
-									],
-									"path": [
-										"did.json"
+										"{{did_doc_url}}"
 									]
 								}
 							},

--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -38,7 +38,7 @@
 										"exec": [
 											"const convertDidToEndpoint = (did) => {",
 											"  const regex = new RegExp(",
-											"    `did:web:(?<host>[a-zA-Z0-9/.\\\\-_]+)(:*)(?<port>[0-9]+)*(:*)(?<path>[a-zA-Z0-9/.:\\\\-_]*)`",
+											"    `did:web:(?<host>[a-zA-Z0-9/.\\\\-_]+)(?:%3A(?<port>[0-9]+))?(:*)(?<path>[a-zA-Z0-9/.:\\\\-_]*)`",
 											"  );",
 											"  const match = did.match(regex);",
 											"  if (!match) {",


### PR DESCRIPTION
This determines the location of the DID Document from `ORGANIZATION_DID_WEB`, rather than assuming it to be on `API_BASE_URL/did.json`. This supports multi-tenant situations (as well as potentially hosting the DID Doc elsewhere). 