### PR TITLE
chore: differentiate between 400 errors

### DIFF
--- a/docs/openapi/resources/credential-verifier.yml
+++ b/docs/openapi/resources/credential-verifier.yml
@@ -29,7 +29,16 @@ post:
           schema:
             $ref: "../schemas/VerificationResult.yml"
     '400':
-      $ref: '../responses/BadRequest.yml'
+      description: |
+        The request was invalid, either because the request body did not conform
+        to the required schema, or because the request contained an invalid
+        proof signature.
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: '../responses/ErrInvalidRequestBody.yml'
+              - $ref: '../responses/ErrInvalidSignature.yml'
     '401':
       $ref: '../responses/Unauthenticated.yml'
     '403':

--- a/docs/openapi/responses/ErrInvalidRequestBody.yml
+++ b/docs/openapi/responses/ErrInvalidRequestBody.yml
@@ -1,0 +1,9 @@
+description: |
+  ErrInvalidRequestBody is returned when the request body does not conform to
+  the required schema.
+allOf:
+  - $ref: '../schemas/Error.yml'
+  - type: object
+    properties:
+      message:
+        enum: ['Invalid Request Body: The request body does not conform to the required schema']

--- a/docs/openapi/responses/ErrInvalidSignature.yml
+++ b/docs/openapi/responses/ErrInvalidSignature.yml
@@ -1,0 +1,9 @@
+description: |
+  ErrInvalidSignature is returned when the signature provided in the request
+  body is invalid, but the request is otherwise schema-conformant.
+allOf:
+  - $ref: '../schemas/Error.yml'
+  - type: object
+    properties:
+      message:
+        enum: ['Invalid Signature: The request body contains an invalid signature']


### PR DESCRIPTION
This PR introduces two new specific error responses for use when the request body is not conformant to the expected schema, and for when the request body contains an invalid signature.

Fixes #406 