### PR TITLE
docs: add description to /presentations endpoint schema

### DIFF
--- a/docs/openapi/resources/presentations.yml
+++ b/docs/openapi/resources/presentations.yml
@@ -1,6 +1,9 @@
 post:
   summary: Present
   operationId: submitPresentationWithOAuth2Security
+  description: >
+    Create a presentation. This endpoint allows clients holding a valid OAuth2
+    access token (with the appropriate scopes) to create a presentation.
   tags:
     - Presentations
   security:


### PR DESCRIPTION
This PR adds a description to the OpenAPI schema for the `POST` request in the `/presentations` endpoint.

Fixes #369 