### PR TITLE
feat: test proof created date within 10s

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -2219,84 +2219,6 @@
 									"response": []
 								},
 								{
-									"name": "credentials_issue:options.created:wrong_type",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"exec": [
-													"pm.test(\"status code is 400\", function () {",
-													" pm.response.to.have.status(400);",
-													"});",
-													"",
-													"pm.test(\"response validates against schema\", function() {",
-													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
-													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
-													"});",
-													"",
-													""
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "prerequest",
-											"script": {
-												"exec": [
-													"let rawBody = pm.variables.get(\"rawBody\");",
-													"",
-													"// options.created must be a string when present",
-													"rawBody.options.created = [\"an\", \"array\"];",
-													"",
-													"// Request body must be serialized before sending over the wire.",
-													"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [
-												{
-													"key": "token",
-													"value": "{{access_token}}",
-													"type": "string"
-												}
-											]
-										},
-										"method": "POST",
-										"header": [
-											{
-												"key": "Accept",
-												"value": "application/json",
-												"type": "text"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{{requestBody}}",
-											"options": {
-												"raw": {
-													"language": "json"
-												}
-											}
-										},
-										"url": {
-											"raw": "{{API_BASE_URL}}/credentials/issue",
-											"host": [
-												"{{API_BASE_URL}}"
-											],
-											"path": [
-												"credentials",
-												"issue"
-											]
-										}
-									},
-									"response": []
-								},
-								{
 									"name": "credentials_issue:options.credentialStatus:wrong_type",
 									"event": [
 										{
@@ -2723,6 +2645,13 @@
 											"pm.test(\"response issuanceDate matches request credential.issuanceDate\", function() {",
 											" const { issuanceDate } = pm.response.json();",
 											" pm.expect(issuanceDate).to.equal(pm.variables.get(\"issuance_date\"))",
+											"});",
+											"",
+											"pm.test(\"response proof.created is close to 'now'\", function() {",
+											" const { proof } = pm.response.json();",
+											" const delta = Math.abs(Date.parse(proof.created) - Date.now());",
+											" const tenSecondsInMs = 10000;",
+											" pm.expect(delta).to.be.lessThan(tenSecondsInMs);",
 											"});",
 											""
 										],
@@ -3248,8 +3177,7 @@
 							"        \"credentialSubject\": {}",
 							"    },",
 							"    \"options\": {",
-							"        \"type\": \"Ed25519Signature2018\",",
-							"        \"created\": \"2020-04-02T18:48:36Z\"",
+							"        \"type\": \"Ed25519Signature2018\"",
 							"    }",
 							"});",
 							"",


### PR DESCRIPTION
This PR removes the negative testing related to bad values in `proof.created` (see #428), and adds positive testing to check that the `proof.created` value returned from a post to `/credentials/issue` is within 10 seconds of the current time.

Fixes #352
References #351 
