### PR TITLE
feat: add openapi linting to ci process

### DIFF
--- a/.github/workflows/publish-openapi-spec.yml
+++ b/.github/workflows/publish-openapi-spec.yml
@@ -21,6 +21,10 @@ jobs:
           cache: 'npm'
       - run: npm ci
 
+      # OpenAPI YAML must pass linting
+      - name: Lint OpenAPI Specification YAML
+        run: npm run validate-spec
+
       # Build the JSON version of the OpenAPI specification from the YAML source
       # files prior to publishing.
       - name: Build Open API Specification JSON


### PR DESCRIPTION
This PR updates the GitHub workflow that publishes the OpenAPI spec to GitHub Pages to add a step for linting.

Fixes #420 