### PR TITLE
Update `convertDidWebToEndpoint` to return `http://` if run locally

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -15017,7 +15017,7 @@
 					"    const { host, port, path } = match.groups;",
 					"    const hostport = port ? `${host}:${port}` : `${host}`",
 					"    const pathname = path?.split(':').join('/') || '/.well-known';",
-					"    return `https://${hostport}${pathname}/did.json`;",
+					"    return `${port ? 'http' : 'https'}://${hostport}${pathname}/did.json`;",
 					"};",
 					"",
 					"// The pm variable is not available inside global methods.",


### PR DESCRIPTION
This PR updates the `convertDidWebToEndpoint` so it returns an `http` url if a `port` is provided (for local environments). Otherwise it returns an `https` url.