### PR TITLE
feat: add negative testing for options.created

### DIFF
--- a/docs/openapi/schemas/IssueCredentialOptions.yml
+++ b/docs/openapi/schemas/IssueCredentialOptions.yml
@@ -10,7 +10,7 @@ properties:
     enum: ['Ed25519Signature2018', 'JsonWebSignature2020', 'jwt_vc']
   created:
     type: string
-    description: Date the proof was created.
+    description: Date the proof was created. This value MUST be an XML Date Time String.
   credentialStatus:
     type: object
     description: The method of credential status.

--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -5276,6 +5276,396 @@
 									"response": []
 								},
 								{
+									"name": "credentials_issue:options.created:array",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // options.created must be string, not array",
+													"    req.options.created = [pm.variables.get(\"created\")];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/issue",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"issue"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_issue:options.created:boolean",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // options.created must be string, not boolean",
+													"    req.options.created = false;",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/issue",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"issue"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_issue:options.created:integer",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // options.created must be string, not integer",
+													"    req.options.created = 42;",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/issue",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"issue"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_issue:options.created:null",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // options.created must be string, not null",
+													"    req.options.created = null;",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/issue",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"issue"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_issue:options.created:object",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // options.created must be string, not object",
+													"    req.options.created = {};",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/issue",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"issue"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_issue:options.created:invalid",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // options.created must be a valid XML date time string",
+													"    req.options.created = \"not an xml date time string\";",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/issue",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"issue"
+											]
+										}
+									},
+									"response": []
+								},
+								{
 									"name": "credentials_issue:options.credentialStatus:array",
 									"event": [
 										{
@@ -6566,6 +6956,11 @@
 											" const schemaString = pm.collectionVariables.get(\"responseSchema201CredentialsIssue\");",
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 											"});",
+											"",
+											"pm.test(\"response proof.created matches request options.created\", function() {",
+											" const { created } = pm.response.json().proof;",
+											" pm.expect(created).to.equal(pm.variables.get(\"created\"))",
+											"});",
 											""
 										],
 										"type": "text/javascript"
@@ -6575,13 +6970,9 @@
 									"listen": "prerequest",
 									"script": {
 										"exec": [
-											"let rawBody = pm.variables.get(\"rawBody\");",
-											"",
-											"// options.created can be an optional string value",
-											"rawBody.options.created = \"an arbitrary string\";",
-											"",
-											"// Request body must be serialized before sending over the wire.",
-											"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
+											"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+											"    req.options.created = pm.variables.get(\"created\");",
+											"}));"
 										],
 										"type": "text/javascript"
 									}
@@ -6737,6 +7128,7 @@
 							"pm.variables.set(\"credentialSubject\", \"did:example:123\")",
 							"pm.variables.set(\"issuanceDate\", \"2006-01-02T15:04:05Z\");",
 							"pm.variables.set(\"issuer\", pm.environment.get(\"ORGANIZATION_DID_WEB\"));",
+							"pm.variables.set(\"created\", \"2006-01-02T15:04:05Z\");",
 							"",
 							"// Minimal request body should represent the minimum set of data required",
 							"// to issue a valid credential. This should exclude all optional items, and",


### PR DESCRIPTION
This PR adds negative testing for the `options.created` property in a `/credentials/issue` request. Specifically, it ensures that the optional value is a valid XML Date Time String.

A positive test has also been added to ensure that the value of `proof.created` in the response body matches the given value of `options.created`.

Fixes #428