### PR TITLE
feat: add 422 response for credentials/issue

### DIFF
--- a/docs/openapi/resources/credential-issuer.yml
+++ b/docs/openapi/resources/credential-issuer.yml
@@ -35,5 +35,11 @@ post:
       $ref: '../responses/Unauthenticated.yml'
     '403':
       $ref: '../responses/Unauthorized.yml'
+    '422':
+      description: Unknown Issuer
+      content:
+        application/json:
+          schema:
+            $ref: '../responses/ErrUnknownIssuer.yml'
     '500':
       $ref: '../responses/UnexpectedError.yml'

--- a/docs/openapi/responses/ErrUnknownIssuer.yml
+++ b/docs/openapi/responses/ErrUnknownIssuer.yml
@@ -1,0 +1,10 @@
+description: |
+  ErrUnknownIssuer is returned when the implementation does not have private
+  key material for the requested `issuer`, and is therefore unable to issue
+  the requested credential.
+allOf:
+  - $ref: '../schemas/Error.yml'
+  - type: object
+    properties:
+      message:
+        enum: ['Unknown Issuer: Unable to issue credentials for specified issuer']

--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "7f2d134c-0652-4763-bcaa-ff75092b3e39",
+		"_postman_id": "f5f17919-82a1-4db5-be95-0f985635313d",
 		"name": "Conformance Suite",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "4338127"
@@ -2747,15 +2747,14 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"status code is 400\", function () {",
-													" pm.response.to.have.status(400);",
+													"pm.test(\"status code is 422\", function () {",
+													" pm.response.to.have.status(422);",
 													"});",
 													"",
 													"pm.test(\"response validates against schema\", function() {",
-													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema422CredentialsIssue\");",
 													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 													"});",
-													"",
 													""
 												],
 												"type": "text/javascript"
@@ -3202,12 +3201,12 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"status code is 400\", function () {",
-													" pm.response.to.have.status(400);",
+													"pm.test(\"status code is 422\", function () {",
+													" pm.response.to.have.status(422);",
 													"});",
 													"",
 													"pm.test(\"response validates against schema\", function() {",
-													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema422CredentialsIssue\");",
 													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 													"});",
 													"",
@@ -15134,6 +15133,11 @@
 		{
 			"key": "responseSchema200CredentialsVerify",
 			"value": "{\"title\":\"Verification Result\",\"type\":\"object\",\"properties\":{\"verified\":{\"type\":\"boolean\"},\"verifications\":{\"type\":\"array\",\"items\":{\"title\":\"Verification\",\"type\":\"object\",\"properties\":{\"title\":{\"type\":\"string\",\"enum\":[\"Proof\",\"Activation\",\"Expired\",\"Revocation\"]},\"status\":{\"type\":\"string\",\"enum\":[\"good\",\"bad\"]},\"description\":{\"type\":\"string\"}},\"required\":[\"title\",\"status\"]}}},\"required\":[\"verified\"]}",
+			"type": "string"
+		},
+		{
+			"key": "responseSchema422CredentialsIssue",
+			"value": "{\"description\":\"ErrUnknownIssuer is returned when the implementation does not have private\\nkey material for the requested `issuer`, and is therefore unable to issue\\nthe requested credential.\\n\",\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"message\":{\"enum\":[\"Unknown Issuer: Unable to issue credentials for specified issuer\"]}}}]}",
 			"type": "string"
 		}
 	]

--- a/tests/update_conformance_schemas.sh
+++ b/tests/update_conformance_schemas.sh
@@ -83,6 +83,12 @@ update_postman \
   "responseSchema403" \
   "$(get_schema '.paths["/credentials/issue"].post.responses["403"].content["application/json"].schema')"
 
+# Credentials - Issue [422]
+update_postman \
+"conformance_suite.postman_collection.json" \
+  "responseSchema422CredentialsIssue" \
+  "$(get_schema '.paths["/credentials/issue"].post.responses["422"].content["application/json"].schema')"
+
 # Credentials - Issue [500]
 update_postman \
 "conformance_suite.postman_collection.json" \


### PR DESCRIPTION
This PR adds support for 422 response when issuing a credential using an issuer that is unknown to the implementation.

Fixes #349 