### PR TITLE
fix: update positive tests to use mutation

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -6267,7 +6267,7 @@
 											"",
 											"pm.test(\"response issuer matches request credential.issuer\", function() {",
 											" const { issuer } = pm.response.json();",
-											" pm.expect(issuer).to.equal(pm.variables.get(\"credential_issuer_id\"))",
+											" pm.expect(issuer).to.equal(pm.variables.get(\"issuer\"))",
 											"});",
 											"",
 											"pm.test(\"response credentialSubject matches request credential.credentialSubject\", function() {",
@@ -6277,7 +6277,7 @@
 											"",
 											"pm.test(\"response issuanceDate matches request credential.issuanceDate\", function() {",
 											" const { issuanceDate } = pm.response.json();",
-											" pm.expect(issuanceDate).to.equal(pm.variables.get(\"issuance_date\"))",
+											" pm.expect(issuanceDate).to.equal(pm.variables.get(\"issuanceDate\"))",
 											"});",
 											"",
 											"pm.test(\"response proof.created is close to 'now'\", function() {",
@@ -6295,10 +6295,10 @@
 									"listen": "prerequest",
 									"script": {
 										"exec": [
-											"let rawBody = pm.variables.get(\"rawBody\");",
-											"",
-											"// Request body must be serialized before sending over the wire.",
-											"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
+											"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+											"    // noop",
+											"}));",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -6359,13 +6359,10 @@
 									"listen": "prerequest",
 									"script": {
 										"exec": [
-											"let rawBody = pm.variables.get(\"rawBody\");",
-											"",
-											"// credential.id is optional",
-											"rawBody.credential.id = pm.variables.get(\"credential_id\");",
-											"",
-											"// Request body must be serialized before sending over the wire.",
-											"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
+											"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+											"    req.credential.id = pm.variables.get(\"credentialId\");",
+											"}));",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -6422,9 +6419,9 @@
 											" const { issuer } = pm.response.json();",
 											" // Implementations may reduce object with just \"id\" property to a bare string",
 											" if (typeof issuer === 'string') {",
-											"  pm.expect(issuer).to.equal(pm.variables.get(\"credential_issuer_id\"))",
+											"  pm.expect(issuer).to.equal(pm.variables.get(\"issuer\"))",
 											" } else {",
-											"  pm.expect(issuer.id).to.equal(pm.variables.get(\"credential_issuer_id\"))",
+											"  pm.expect(issuer.id).to.equal(pm.variables.get(\"issuer\"))",
 											" }",
 											"});",
 											""
@@ -6436,13 +6433,11 @@
 									"listen": "prerequest",
 									"script": {
 										"exec": [
-											"let rawBody = pm.variables.get(\"rawBody\");",
-											"",
-											"// credential.issuer can be an object with required 'id' element",
-											"rawBody.credential.issuer = {\"id\": pm.variables.get(\"credential_issuer_id\") };",
-											"",
-											"// Request body must be serialized before sending over the wire.",
-											"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
+											"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+											"    // credential.issuer can be an object with required 'id' element",
+											"    req.credential.issuer = {\"id\": pm.variables.get(\"issuer\") };",
+											"}));",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -6575,13 +6570,11 @@
 									"listen": "prerequest",
 									"script": {
 										"exec": [
-											"let rawBody = pm.variables.get(\"rawBody\");",
-											"",
-											"// options.created can be an optional string value",
-											"rawBody.options.created = \"an arbitrary string\";",
-											"",
-											"// Request body must be serialized before sending over the wire.",
-											"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
+											"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+											"    // options.created can be an optional string value",
+											"    req.options.created = \"an arbitrary string\";",
+											"}));",
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -6642,13 +6635,11 @@
 									"listen": "prerequest",
 									"script": {
 										"exec": [
-											"let rawBody = pm.variables.get(\"rawBody\");",
-											"",
-											"// options.credentialStatus can be an optional object",
-											"rawBody.options.credentialStatus = {\"type\": \"RevocationList2020Status\"};",
-											"",
-											"// Request body must be serialized before sending over the wire.",
-											"pm.variables.set(\"requestBody\", JSON.stringify(rawBody));"
+											"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+											"    // options.credentialStatus can be an optional object",
+											"    req.options.credentialStatus = {\"type\": \"RevocationList2020Status\"};",
+											"}));",
+											""
 										],
 										"type": "text/javascript"
 									}


### PR DESCRIPTION
This PR fixes a bug in the positive tests for `/credentials/issue` where a change to the way request body is mutated was not carried over from the negative tests.