### PR TITLE
feat: add cache-clearing requests

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -7,6 +7,67 @@
 	},
 	"item": [
 		{
+			"name": "Clear Cache",
+			"item": [
+				{
+					"name": "Clear Token Cache",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"pm.globals.unset(\"tokenCache\");",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "HEAD",
+						"header": [],
+						"url": {
+							"raw": "www.example.com",
+							"host": [
+								"www",
+								"example",
+								"com"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Clear DID Web Cache",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"pm.globals.unset(\"didWebCache\");",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "HEAD",
+						"header": [],
+						"url": {
+							"raw": "www.example.com",
+							"host": [
+								"www",
+								"example",
+								"com"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
 			"name": "Discovery - API Configuration",
 			"item": [
 				{


### PR DESCRIPTION
This PR adds two requests that will be executed before the conformance requests. These two new requests will remove any existing `didWebCache` and `tokenCache`. These requests can also be used manually to clear the respective caches on-demand, e.g., during testing.