### PR TITLE
fix: pin python to 3.10 in actions

### DIFF
--- a/.github/workflows/conformance-run.yml
+++ b/.github/workflows/conformance-run.yml
@@ -102,11 +102,11 @@ jobs:
       - name: Build JSON Index
         run: npm run report:index -- --folder conformance
 
-      # Set up Python 3.x
-      - name: Set up Python 3.x
+      # Set up Python 3.10
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.10"
           cache: pip
       - run: pip install -r ./reporting/requirements.txt
 

--- a/.github/workflows/interoperability-report.yml
+++ b/.github/workflows/interoperability-report.yml
@@ -632,11 +632,11 @@ jobs:
       - name: Build JSON Index
         run: npm run report:index -- --folder interoperability
 
-      # Set up Python 3.x
-      - name: Set up Python 3.x
+      # Set up Python 3.10
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.10"
           cache: pip
       - run: pip install -r ./reporting/requirements.txt
 


### PR DESCRIPTION
New Ubuntu runner image version 20221027.1 upgrades to python 3.11, which causes some issues with module installs.

This PR updates the configuration for `actions/setup-python@v4` in the interop and conformance workflows to pin python to `3.10` instead of `3.x`.

Fix: #458