### PR TITLE
docs: add historical report archive

### DIFF
--- a/.github/workflows/publish-report-index.yml
+++ b/.github/workflows/publish-report-index.yml
@@ -1,0 +1,25 @@
+name: Publish Report Index
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - 'docs/reports/archive/**'
+
+jobs:
+  publish-index:
+    runs-on: ubuntu-latest
+    steps:
+
+      # Check out repo, setup node, and install dependencies.
+      # @see https://github.com/actions/setup-node#usage
+      - uses: actions/checkout@v3
+
+      # Publish reports/archive subfolder to GitHub Pages
+      - name: Publish Open API Specification
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/reports/archive
+          destination_dir: reports/archive

--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@
 
 ## Traceability Interoperability
 
-- [Conformance Test Suite](https://w3id.org/traceability/interoperability/reports/conformance)
-- [Interoperability Test Suite](https://w3id.org/traceability/interoperability/reports/interoperability)
+- [Latest conformance test suite results](https://w3id.org/traceability/interoperability/reports/conformance)
+- [Latest interoperability test suite results](https://w3id.org/traceability/interoperability/reports/interoperability)
+- [Historical test suite result archive](https://w3id.org/traceability/interoperability/reports/archive)
 - [Getting Started](https://github.com/w3c-ccg/traceability-interop/tree/main/reporting)
-- [Conformance Report Archive](https://w3id.org/traceability/interoperability/reports/conformance/index.json)
-- [Interoperability Report Archive](https://w3id.org/traceability/interoperability/reports/interoperability/index.json)
 
 ## About
 

--- a/docs/reports/archive/index.html
+++ b/docs/reports/archive/index.html
@@ -1,0 +1,51 @@
+<html>
+
+<body>
+    <script>
+        (async () => {
+            async function list_directory(user, repo, directory) {
+                const url = `https://api.github.com/repos/${user}/${repo}/git/trees/gh-pages`;
+                directory = directory.split('/').filter(Boolean);
+                const dir = await directory.reduce(async (acc, dir) => {
+                    const { url } = await acc;
+                    const list = await fetch(url).then(res => res.json());
+                    return list.tree.find(node => node.path === dir);
+                }, { url });
+                if (dir) {
+                    const list = await fetch(dir.url).then(res => res.json());
+                    return list.tree.map(node => node.path);
+                }
+            }
+
+            function generate_list(title, suite, folders) {
+                const re = new RegExp(`(?<suite>${suite})\-(?<unixtime>\\d+)`)
+                let htmlString = `<h2>${title}</h2>` + '<ul>';
+
+                for (let folder of folders) {
+                    const match = folder.match(re);
+                    if (!match) {
+                        console.log("no match " + folder);
+                        continue;
+                    }
+                    const { suite, unixtime } = match.groups;
+                    const datestring = new Date(unixtime * 1000).toLocaleString();
+                    htmlString += `<li><a href="https://w3id.org/traceability/interoperability/reports/${folder}">${suite} - ${datestring}</a></li>`;
+                }
+
+                return htmlString + '</ul>';
+            }
+
+            const folders = await list_directory('w3c-ccg', 'traceability-interop', 'reports');
+            folders.reverse();
+
+            let markup = '';
+            markup += generate_list("Conformance Report Archive", 'conformance', folders);
+            markup += generate_list('Interoperability Report Archive', 'interoperability', folders);
+
+            document.getElementsByTagName('body')[0].innerHTML = markup;
+        })()
+    </script>
+
+</body>
+
+</html>


### PR DESCRIPTION
This PR adds an index for historical test suite results and updates the main `README.md` to link to it.

Fixes #364 