### PR TITLE
chore: add a top-level verifiablePresentation

### DIFF
--- a/docs/openapi/resources/presentation-prover.yml
+++ b/docs/openapi/resources/presentation-prover.yml
@@ -32,7 +32,12 @@ post:
       content:
         application/json:
           schema:
-            $ref: "../schemas/SerializedVerifiablePresentation.yml"
+            type: object
+            required:
+              - verifiablePresentation
+            properties:
+              verifiablePresentation:
+                $ref: "../schemas/SerializedVerifiablePresentation.yml"
     '401':
       $ref: '../responses/Unauthenticated.yml'
     '403':


### PR DESCRIPTION
This PR adds a required top-level verifiablePresentation property to the response body of a successful `/presentations/prove` request.

Fixes #456 