### PR TITLE
chore: add bad signature testing

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -14568,6 +14568,76 @@
 									}
 								}
 							]
+						},
+						{
+							"name": "Bad Signature",
+							"item": [
+								{
+									"name": "credentials_verify:bad_signature",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 200\", function () {",
+													" pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema200CredentialsVerify\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													"pm.test(\"response verified is false\", function() {",
+													" const { verified } = pm.response.json();",
+													" pm.expect(verified).to.be.false;",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..mvbcalofPOi7o7nxByyxXCuSOKXuGFM7_W9a8N62-EERarrH4p4T_0c2ZfGnGLiHOvY6Q-dyy38t9HPvXy-MBg\"\n        }\n    }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/verify",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"verify"
+											]
+										}
+									},
+									"response": []
+								}
+							]
 						}
 					]
 				},
@@ -14589,7 +14659,11 @@
 											" const schemaString = pm.collectionVariables.get(\"responseSchema200CredentialsVerify\");",
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 											"});",
-											""
+											"",
+											"pm.test(\"response verified is true\", function() {",
+											" const { verified } = pm.response.json();",
+											" pm.expect(verified).to.be.true;",
+											"});"
 										],
 										"type": "text/javascript"
 									}
@@ -14650,7 +14724,11 @@
 											" const schemaString = pm.collectionVariables.get(\"responseSchema200CredentialsVerify\");",
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 											"});",
-											""
+											"",
+											"pm.test(\"response verified is true\", function() {",
+											" const { verified } = pm.response.json();",
+											" pm.expect(verified).to.be.true;",
+											"});"
 										],
 										"type": "text/javascript"
 									}
@@ -14711,7 +14789,11 @@
 											" const schemaString = pm.collectionVariables.get(\"responseSchema200CredentialsVerify\");",
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 											"});",
-											""
+											"",
+											"pm.test(\"response verified is true\", function() {",
+											" const { verified } = pm.response.json();",
+											" pm.expect(verified).to.be.true;",
+											"});"
 										],
 										"type": "text/javascript"
 									}


### PR DESCRIPTION
This PR adds a test to ensure that an otherwise well-formed verification request with an incorrect JWS signature returns a 200 response with `verified:false`.

Additionally, existing "positive" testing has been updated to validate that the response contains `verified:true`.

Fixes #431