### PR TITLE
chore: add tests for `@context` entry

### DIFF
--- a/docs/openapi/schemas/Credential.yml
+++ b/docs/openapi/schemas/Credential.yml
@@ -7,7 +7,9 @@ required:
   - credentialSubject
 properties:
   '@context':
-    description: This JSON-LD Context defining all terms in the Credential.
+    description: |
+      The JSON-LD Context defining all terms in the Credential. This array
+      MUST contain "https://w3id.org/traceability/v1".
     type: array
     items:
       type: string
@@ -43,7 +45,10 @@ properties:
 
 example:
   {
-    '@context': ['https://www.w3.org/2018/credentials/v1'],
+    '@context': [
+      'https://www.w3.org/2018/credentials/v1',
+      'https://w3id.org/traceability/v1'
+    ],
     'id': 'urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded',
     'type': ['VerifiableCredential'],
     'issuer': 'did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn',

--- a/docs/openapi/schemas/Presentation.yml
+++ b/docs/openapi/schemas/Presentation.yml
@@ -5,6 +5,9 @@ required:
   - type
 properties:
   '@context':
+    description: |
+      The JSON-LD Context defining all terms in the Presentation. This array
+      MUST contain "https://w3id.org/traceability/v1".
     type: array
     items:
       type: string
@@ -23,13 +26,19 @@ properties:
 
 example:
   {
-    '@context': ['https://www.w3.org/2018/credentials/v1'],
+    '@context': [
+      'https://www.w3.org/2018/credentials/v1',
+      'https://w3id.org/traceability/v1'
+    ],
     'type': ['VerifiablePresentation'],
     'holder': 'did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn',
     'verifiableCredential':
       [
         {
-          '@context': ['https://www.w3.org/2018/credentials/v1'],
+          '@context': [
+            'https://www.w3.org/2018/credentials/v1',
+            'https://w3id.org/traceability/v1'
+          ],
           'id': 'urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded',
           'type': ['VerifiableCredential'],
           'issuer': 'did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn',

--- a/docs/openapi/schemas/RevocationListCredential.yml
+++ b/docs/openapi/schemas/RevocationListCredential.yml
@@ -10,7 +10,11 @@ required:
   - id
 example:
   {
-    '@context': ['https://www.w3.org/2018/credentials/v1', 'https://w3id.org/vc-revocation-list-2020/v1'],
+    '@context': [
+      'https://www.w3.org/2018/credentials/v1',
+      'https://w3id.org/vc-revocation-list-2020/v1',
+      'https://w3id.org/traceability/v1'
+    ],
     'id': 'https://api.did.actor/revocation-lists/1.json',
     'issuer': 'did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn',
     'issuanceDate': '2010-01-01T19:23:24Z',

--- a/docs/openapi/schemas/SerializedVerifiableCredential.yml
+++ b/docs/openapi/schemas/SerializedVerifiableCredential.yml
@@ -5,7 +5,10 @@ oneOf:
 
 example:
   {
-    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/traceability/v1"
+    ],
     "id": "urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded",
     "type": ["VerifiableCredential"],
     "issuer": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",

--- a/docs/openapi/schemas/SerializedVerifiablePresentation.yml
+++ b/docs/openapi/schemas/SerializedVerifiablePresentation.yml
@@ -10,6 +10,7 @@ example:
       [
         "https://www.w3.org/2018/credentials/v1",
         "https://w3id.org/security/suites/jws-2020/v1",
+        "https://w3id.org/traceability/v1"
       ],
     "type": ["VerifiablePresentation"],
     "holder": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
@@ -20,6 +21,7 @@ example:
             [
               "https://www.w3.org/2018/credentials/v1",
               "https://w3id.org/security/suites/jws-2020/v1",
+              "https://w3id.org/traceability/v1"
             ],
           "id": "urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded",
           "type": ["VerifiableCredential"],

--- a/docs/openapi/schemas/TraceablePresentation.yml
+++ b/docs/openapi/schemas/TraceablePresentation.yml
@@ -33,6 +33,7 @@ example:
             [
               "https://www.w3.org/2018/credentials/v1",
               "https://w3id.org/vc-revocation-list-2020/v1",
+              "https://w3id.org/traceability/v1"
             ],
           "id": "urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded",
           "type": ["VerifiableCredential"],

--- a/docs/openapi/schemas/VerifiableCredential.yml
+++ b/docs/openapi/schemas/VerifiableCredential.yml
@@ -10,7 +10,10 @@ allOf:
         $ref: "./CredentialLinkedDataProof.yml"
 example:
   {
-    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/traceability/v1"
+    ],
     "id": "urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded",
     "type": ["VerifiableCredential"],
     "issuer": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",

--- a/docs/openapi/schemas/VerifiablePresentation.yml
+++ b/docs/openapi/schemas/VerifiablePresentation.yml
@@ -10,7 +10,11 @@ allOf:
         $ref: "./PresentationLinkedDataProof.yml"
 example:
   {
-    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    "@context":
+      [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://w3id.org/traceability/v1",
+      ],
     "id": "urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded",
     "type": ["VerifiablePresentation"],
     "holder": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
@@ -21,6 +25,7 @@ example:
             [
               "https://www.w3.org/2018/credentials/v1",
               "https://w3id.org/vc-revocation-list-2020/v1",
+              "https://w3id.org/traceability/v1",
             ],
           "id": "urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded",
           "type": ["VerifiableCredential"],

--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -612,6 +612,72 @@
 									"response": []
 								},
 								{
+									"name": "credentials_issue:credential.@context:invalid",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // \"credential.@context\" must contain \"https://w3id.org/traceability/v1\"",
+													"    req.credential[\"@context\"] = [\"https://www.w3.org/2018/credentials/v1\"];",
+													"}));",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/issue",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"issue"
+											]
+										}
+									},
+									"response": []
+								},
+								{
 									"name": "credentials_issue:credential.@context:boolean",
 									"event": [
 										{
@@ -6715,6 +6781,12 @@
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 											"});",
 											"",
+											"// Current OpenAPI v3.x schema cannot require specific array contents",
+											"pm.test(\"response @context contains traceability/v1\", function() {",
+											" const context = pm.response.json().verifiableCredential[\"@context\"];",
+											" pm.expect(context).to.contain(\"https://w3id.org/traceability/v1\");",
+											"});",
+											"",
 											"pm.test(\"response issuer matches request credential.issuer\", function() {",
 											" const { issuer } = pm.response.json().verifiableCredential;",
 											" pm.expect(issuer).to.equal(pm.variables.get(\"issuer\"))",
@@ -6800,6 +6872,12 @@
 											" const schemaString = pm.collectionVariables.get(\"responseSchema201CredentialsIssue\");",
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 											"});",
+											"",
+											"// Current OpenAPI v3.x schema cannot require specific array contents",
+											"pm.test(\"response @context contains traceability/v1\", function() {",
+											" const context = pm.response.json().verifiableCredential[\"@context\"];",
+											" pm.expect(context).to.contain(\"https://w3id.org/traceability/v1\");",
+											"});",
 											""
 										],
 										"type": "text/javascript"
@@ -6863,6 +6941,12 @@
 											"pm.test(\"response validates against schema\", function() {",
 											" const schemaString = pm.collectionVariables.get(\"responseSchema201CredentialsIssue\");",
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+											"});",
+											"",
+											"// Current OpenAPI v3.x schema cannot require specific array contents",
+											"pm.test(\"response @context contains traceability/v1\", function() {",
+											" const context = pm.response.json().verifiableCredential[\"@context\"];",
+											" pm.expect(context).to.contain(\"https://w3id.org/traceability/v1\");",
 											"});",
 											"",
 											"pm.test(\"response issuer matches request credential.issuer.id\", function() {",
@@ -6940,6 +7024,12 @@
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 											"});",
 											"",
+											"// Current OpenAPI v3.x schema cannot require specific array contents",
+											"pm.test(\"response @context contains traceability/v1\", function() {",
+											" const context = pm.response.json().verifiableCredential[\"@context\"];",
+											" pm.expect(context).to.contain(\"https://w3id.org/traceability/v1\");",
+											"});",
+											"",
 											"pm.test(\"response credentialSubject.id matches request credential.credentialSubject.id\", function() {",
 											" const { credentialSubject } = pm.response.json().verifiableCredential;",
 											" pm.expect(credentialSubject.id).to.equal(pm.variables.get(\"credentialSubject\"))",
@@ -7009,6 +7099,12 @@
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
 											"});",
 											"",
+											"// Current OpenAPI v3.x schema cannot require specific array contents",
+											"pm.test(\"response @context contains traceability/v1\", function() {",
+											" const context = pm.response.json().verifiableCredential[\"@context\"];",
+											" pm.expect(context).to.contain(\"https://w3id.org/traceability/v1\");",
+											"});",
+											"",
 											"pm.test(\"response proof.created matches request options.created\", function() {",
 											" const { created } = pm.response.json().verifiableCredential.proof;",
 											" pm.expect(created).to.equal(pm.variables.get(\"created\"))",
@@ -7075,6 +7171,12 @@
 											"pm.test(\"response validates against schema\", function() {",
 											" const schemaString = pm.collectionVariables.get(\"responseSchema201CredentialsIssue\");",
 											" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+											"});",
+											"",
+											"// Current OpenAPI v3.x schema cannot require specific array contents",
+											"pm.test(\"response @context contains traceability/v1\", function() {",
+											" const context = pm.response.json().verifiableCredential[\"@context\"];",
+											" pm.expect(context).to.contain(\"https://w3id.org/traceability/v1\");",
 											"});",
 											""
 										],
@@ -7192,7 +7294,8 @@
 							"pm.variables.set(\"minimalRequestBody\", {",
 							"    \"credential\": {",
 							"        \"@context\": [",
-							"            \"https://www.w3.org/2018/credentials/v1\"",
+							"            \"https://www.w3.org/2018/credentials/v1\",",
+							"            \"https://w3id.org/traceability/v1\"",
 							"        ],",
 							"        \"type\": [",
 							"            \"VerifiableCredential\"",
@@ -10387,7 +10490,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"id\": [\n            \"urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..iom-sOLAz9-9FhadLRpqOYXXBhx4Rgwa3I3w1oh087xFQqIMhVTzcSpHCGdGWu2QT1KwrrgVAXPeTT2EthmxBg\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"id\": [\n            \"urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..iom-sOLAz9-9FhadLRpqOYXXBhx4Rgwa3I3w1oh087xFQqIMhVTzcSpHCGdGWu2QT1KwrrgVAXPeTT2EthmxBg\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -10434,7 +10537,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"id\": false,\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..xftqB9cBFsSe226cWEZ4wr5sfxlAOJYYo6yjwPCVeHDdk6OoWGjZQGO7xXpSidrrr6e1imP18LiFK34xtRWADQ\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"id\": false,\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..xftqB9cBFsSe226cWEZ4wr5sfxlAOJYYo6yjwPCVeHDdk6OoWGjZQGO7xXpSidrrr6e1imP18LiFK34xtRWADQ\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -10481,7 +10584,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"id\": 123,\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..ZqV-qqLOh_Kb4vAdXKBfmFdNyv3FzXJAIYV9JltcYGDAefU3OUOnoaAU2WSEufkuYkvczxfRLhrMKgkoVoIRAA\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"id\": 123,\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..ZqV-qqLOh_Kb4vAdXKBfmFdNyv3FzXJAIYV9JltcYGDAefU3OUOnoaAU2WSEufkuYkvczxfRLhrMKgkoVoIRAA\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -10528,7 +10631,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"id\": null,\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Csadnd3P2WqJLxAeXMkyx4nkvXvSEssOQriVuwYK0_6zyssqkkuAcKpkUFh8rf4J5JVpng9yvb_2263dLMLZCw\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"id\": null,\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Csadnd3P2WqJLxAeXMkyx4nkvXvSEssOQriVuwYK0_6zyssqkkuAcKpkUFh8rf4J5JVpng9yvb_2263dLMLZCw\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -10575,7 +10678,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"id\": {\n            \"key\": \"urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded\"\n        },\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..5J-iTBtI5WNIe9L3kLF22cjjDx6iQuJAgl6yYYoIGMC-X_crKNlSlB5bRJsrb2MV-NDlWMtHe0grtMqRG1N0Bw\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"id\": {\n            \"key\": \"urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded\"\n        },\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..0Nrj_srTLYyA-9ZVA_dkVGjUcKx6xELHjbbdppEMFPGEN5c2gPXgstNRjnrr8hhMMegSAbvGASKWseBXGR9uAQ\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -10622,7 +10725,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..V5PnQzCWxrPiCYT-WAyKAnypebgwYeD7lX_hyIjFa_lbJje23pZAfFdgnlqBnXLd19Ksa8fZpCE9TN7kAjzxDA\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..a5NS2rMhgsOcN1dYaNHuMMfcuscEbs0zL9JCQVt7y1iy7q1g9pGUlhFwffQUNj_M6JgmHG2e-V_QNPQN9b0rDQ\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -10881,7 +10984,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": \"VerifiableCredential\",\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Csadnd3P2WqJLxAeXMkyx4nkvXvSEssOQriVuwYK0_6zyssqkkuAcKpkUFh8rf4J5JVpng9yvb_2263dLMLZCw\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": \"VerifiableCredential\",\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Csadnd3P2WqJLxAeXMkyx4nkvXvSEssOQriVuwYK0_6zyssqkkuAcKpkUFh8rf4J5JVpng9yvb_2263dLMLZCw\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -11246,7 +11349,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..pq8DsjUrDW8TnVRuS8CwfW5Y4dnqYcGsGryNh1gi-BW7vK0_f3gcnDpwJ0HTiHuNm_AyIVWJUPC2ZQHeiCB6CA\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..pq8DsjUrDW8TnVRuS8CwfW5Y4dnqYcGsGryNh1gi-BW7vK0_f3gcnDpwJ0HTiHuNm_AyIVWJUPC2ZQHeiCB6CA\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -11293,7 +11396,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": [\n            \"did:example:123\"\n        ],\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..x7a3s_8HfmUqGT6SDkktN-jeRmBR2xQ_9tOhJx4kEG3SCsRTySfDxya9yy57LNv__qbY1eMkm9SNrwdYiqlBAA\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": [\n            \"did:example:123\"\n        ],\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..x7a3s_8HfmUqGT6SDkktN-jeRmBR2xQ_9tOhJx4kEG3SCsRTySfDxya9yy57LNv__qbY1eMkm9SNrwdYiqlBAA\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -11340,7 +11443,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": false,\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..mMaPSvG48oEf3bv0t-6eLR3zvU3_BKoRIkgzkuZfm8zvjqbI7iy05D8k1mTeoSZEw3xYV-_sH1rChqGmmp7KDQ\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": false,\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..mMaPSvG48oEf3bv0t-6eLR3zvU3_BKoRIkgzkuZfm8zvjqbI7iy05D8k1mTeoSZEw3xYV-_sH1rChqGmmp7KDQ\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -11387,7 +11490,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": 123,\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..rAVfo-Gnj0vUX6yDAr7pslI6XAAyF2LHTXpiZEmnH5Hb4RsKcmDZZawaLSCg931y1cBUgZ1PQvGbJEdb094ZDQ\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": 123,\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..rAVfo-Gnj0vUX6yDAr7pslI6XAAyF2LHTXpiZEmnH5Hb4RsKcmDZZawaLSCg931y1cBUgZ1PQvGbJEdb094ZDQ\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -11434,7 +11537,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": null,\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..pq8DsjUrDW8TnVRuS8CwfW5Y4dnqYcGsGryNh1gi-BW7vK0_f3gcnDpwJ0HTiHuNm_AyIVWJUPC2ZQHeiCB6CA\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": null,\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..pq8DsjUrDW8TnVRuS8CwfW5Y4dnqYcGsGryNh1gi-BW7vK0_f3gcnDpwJ0HTiHuNm_AyIVWJUPC2ZQHeiCB6CA\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -11481,7 +11584,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": {},\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..BECBu6If6NVwC5rval2DG_n1znlYEyuy8m-akfpYk2JLDVw5zV_d62YTgwyA0q5zzmWDep8TALuV5n5sSdJFCw\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": {},\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..BECBu6If6NVwC5rval2DG_n1znlYEyuy8m-akfpYk2JLDVw5zV_d62YTgwyA0q5zzmWDep8TALuV5n5sSdJFCw\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -11528,7 +11631,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": {\n            \"id\": [\n                \"did:example:123\"\n            ]\n        },\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..vv4qa5LGRlgeMxW5G5VjEKDfjKKosQnvpx6oapYDlfUSWVagQsDoDcRmkotKzFHDcTh-opjGLp__agL6_d4OCw\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": {\n            \"id\": [\n                \"did:example:123\"\n            ]\n        },\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..vv4qa5LGRlgeMxW5G5VjEKDfjKKosQnvpx6oapYDlfUSWVagQsDoDcRmkotKzFHDcTh-opjGLp__agL6_d4OCw\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -11575,7 +11678,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": {\n            \"id\": false\n        },\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..TTwcmWS6_0_t8XPlAGXbzWVSL_dL7OeYojY0FZz1WXCFvDfeAQtMh3dcIxuCeDqON6St3PODGfxluO_q1vWCDw\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": {\n            \"id\": false\n        },\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..TTwcmWS6_0_t8XPlAGXbzWVSL_dL7OeYojY0FZz1WXCFvDfeAQtMh3dcIxuCeDqON6St3PODGfxluO_q1vWCDw\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -11622,7 +11725,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": {\n            \"id\": 123\n        },\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..wpkNYYEOCjKMWm9xTYNn0J7IgXZQbbkEoohMQbloz_Zxb15UVu6DqiqsENotAeHvlRWd7RH2O9v4FwWBeqvPDw\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": {\n            \"id\": 123\n        },\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..wpkNYYEOCjKMWm9xTYNn0J7IgXZQbbkEoohMQbloz_Zxb15UVu6DqiqsENotAeHvlRWd7RH2O9v4FwWBeqvPDw\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -11669,7 +11772,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": {\n            \"id\": null\n        },\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..BECBu6If6NVwC5rval2DG_n1znlYEyuy8m-akfpYk2JLDVw5zV_d62YTgwyA0q5zzmWDep8TALuV5n5sSdJFCw\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": {\n            \"id\": null\n        },\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..BECBu6If6NVwC5rval2DG_n1znlYEyuy8m-akfpYk2JLDVw5zV_d62YTgwyA0q5zzmWDep8TALuV5n5sSdJFCw\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -11716,7 +11819,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": {\n            \"id\": {\n                \"key\": \"did:example:123\"\n            }\n        },\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..bHJmwuqqXWMdd298m7RCTGyGoAzsCx1y9tewaHukqaJJoPn2-TLDCQuXvlnFeAYAE_Cy3j1UScfoVx5k-eclAQ\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": {\n            \"id\": {\n                \"key\": \"did:example:123\"\n            }\n        },\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..4x5xT7i6SOYZ2xoyxzXT8uh0iLvuJKsaEi5AHunTghGIyojcl7qPoXS7-zIBtAzdJ_hQ0Y0FUTCtt_iCymTcAg\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -11763,7 +11866,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..QU131f8dSzen-Dpxf0_p8mCPqhRA6wTO_1rRT4HbsYg0OuRNx_b4x8UtsOoeyuA38K5aL9p7xKeRYf19mmbZDw\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..QU131f8dSzen-Dpxf0_p8mCPqhRA6wTO_1rRT4HbsYg0OuRNx_b4x8UtsOoeyuA38K5aL9p7xKeRYf19mmbZDw\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -11810,7 +11913,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": [\n            \"2010-01-01T19:23:24Z\"\n        ],\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..OzKfWk00QpV3_FJru3xJ3_ktwlU4O68prZWWCmdy3mQTbCz2lPFRl2sB4AkdD3AZUFMAnwxhscd9B0UnqxTZCw\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": [\n            \"2010-01-01T19:23:24Z\"\n        ],\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..OzKfWk00QpV3_FJru3xJ3_ktwlU4O68prZWWCmdy3mQTbCz2lPFRl2sB4AkdD3AZUFMAnwxhscd9B0UnqxTZCw\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -11857,7 +11960,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": false,\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..1W7WM5cXb0daWooGxEOYn_zm72mkmpF_tu8Fij39luQwNGDgK7h4nZGBFcS80HTVqiBKxzlhGq1yNnpUlLG-Ag\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": false,\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..1W7WM5cXb0daWooGxEOYn_zm72mkmpF_tu8Fij39luQwNGDgK7h4nZGBFcS80HTVqiBKxzlhGq1yNnpUlLG-Ag\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -11904,7 +12007,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": 123,\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..dkiU2sStrvQWiNFK8cKmCbAcRGsC9kbDdKyr-NRlPc9ORQczitwUEymjviemIi1Oot23VohpyMcSFvgFIKIFDA\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": 123,\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..dkiU2sStrvQWiNFK8cKmCbAcRGsC9kbDdKyr-NRlPc9ORQczitwUEymjviemIi1Oot23VohpyMcSFvgFIKIFDA\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -11951,7 +12054,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": null,\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..QU131f8dSzen-Dpxf0_p8mCPqhRA6wTO_1rRT4HbsYg0OuRNx_b4x8UtsOoeyuA38K5aL9p7xKeRYf19mmbZDw\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": null,\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..QU131f8dSzen-Dpxf0_p8mCPqhRA6wTO_1rRT4HbsYg0OuRNx_b4x8UtsOoeyuA38K5aL9p7xKeRYf19mmbZDw\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -11998,7 +12101,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": {\n            \"key\": \"2010-01-01T19:23:24Z\"\n        },\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..pNIbeUn6DL71QxEWTF1wQTqKfAJET5JB9FlmoLXk4-rv1owG68DqQY6qwcPx6fUbMijsWsXlvaFvzND0jAg1AA\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": {\n            \"key\": \"2010-01-01T19:23:24Z\"\n        },\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..ScdiIJdpg-fZNifwI7dNf0i4fItp-Gf_MGpTO4Z7kp1eQGg-1nf3O3BoaPem94UO-gL2fM-eY3HdNOyTUl7bAA\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -12045,7 +12148,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"not a valid XML Date Time string\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Z0P0ndVABJRB7mCsv4C-EgB-1SxgnfrU2uQBDSwKm2KfB1jBnzsEzY9enxOn7V1lBAPNxELTEaxPCAK7_n3bBg\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"not a valid XML Date Time string\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Z0P0ndVABJRB7mCsv4C-EgB-1SxgnfrU2uQBDSwKm2KfB1jBnzsEzY9enxOn7V1lBAPNxELTEaxPCAK7_n3bBg\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -12092,7 +12195,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..PbhlE_UhX8MVQULs7DoRe-QWk8PcmupGNRf8qCZbMwRE6bP7wyTCcJBQ-XD3Erp2cW9EjVHihTA_VsHi-02WAA\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..PbhlE_UhX8MVQULs7DoRe-QWk8PcmupGNRf8qCZbMwRE6bP7wyTCcJBQ-XD3Erp2cW9EjVHihTA_VsHi-02WAA\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -12139,7 +12242,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": [\n            \"did:example:123\"\n        ],\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Csadnd3P2WqJLxAeXMkyx4nkvXvSEssOQriVuwYK0_6zyssqkkuAcKpkUFh8rf4J5JVpng9yvb_2263dLMLZCw\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": [\n            \"did:example:123\"\n        ],\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Csadnd3P2WqJLxAeXMkyx4nkvXvSEssOQriVuwYK0_6zyssqkkuAcKpkUFh8rf4J5JVpng9yvb_2263dLMLZCw\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -12186,7 +12289,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": false,\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..IXaPbANtKFiA3Sh28esCkg9kdwpHScJg3bOCF7Phmb5n9RC981EeIobgDnMzWIjP4v0S92FDEcZqA_XbW43GDA\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": false,\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..IXaPbANtKFiA3Sh28esCkg9kdwpHScJg3bOCF7Phmb5n9RC981EeIobgDnMzWIjP4v0S92FDEcZqA_XbW43GDA\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -12233,7 +12336,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": 123,\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..iM5Xr2lBqwFIQhq9RI7Dv4K0dzdQ0z7i5YN4ELsstv9vDC9xA-GY2Ft-PsfubsbgVyQsQYjchCv23GULmhauCg\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": 123,\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..iM5Xr2lBqwFIQhq9RI7Dv4K0dzdQ0z7i5YN4ELsstv9vDC9xA-GY2Ft-PsfubsbgVyQsQYjchCv23GULmhauCg\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -12280,7 +12383,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": null,\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..PbhlE_UhX8MVQULs7DoRe-QWk8PcmupGNRf8qCZbMwRE6bP7wyTCcJBQ-XD3Erp2cW9EjVHihTA_VsHi-02WAA\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": null,\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..PbhlE_UhX8MVQULs7DoRe-QWk8PcmupGNRf8qCZbMwRE6bP7wyTCcJBQ-XD3Erp2cW9EjVHihTA_VsHi-02WAA\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -12327,7 +12430,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": \"did:example:123\",\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Csadnd3P2WqJLxAeXMkyx4nkvXvSEssOQriVuwYK0_6zyssqkkuAcKpkUFh8rf4J5JVpng9yvb_2263dLMLZCw\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": \"did:example:123\",\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Csadnd3P2WqJLxAeXMkyx4nkvXvSEssOQriVuwYK0_6zyssqkkuAcKpkUFh8rf4J5JVpng9yvb_2263dLMLZCw\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -12374,7 +12477,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": [\n                \"did:example:123\"\n            ]\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..GBcSurXcOJcVinhthkmqvV40OS1rN2fY57Kad0HMLUuykp14JJCtNw_gmtf6SwZxhB860OVsUmuNbZXsMCi-DQ\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": [\n                \"did:example:123\"\n            ]\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..GBcSurXcOJcVinhthkmqvV40OS1rN2fY57Kad0HMLUuykp14JJCtNw_gmtf6SwZxhB860OVsUmuNbZXsMCi-DQ\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -12421,7 +12524,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": false\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..VWowmcXQAjabeJENG3aOcLzQ9HrvmSIs2pOWcaEMLdJtvJfP7oWohIBiqp94-eo1pd4Ocgk3hT0cLvS5qKBYAg\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": false\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..VWowmcXQAjabeJENG3aOcLzQ9HrvmSIs2pOWcaEMLdJtvJfP7oWohIBiqp94-eo1pd4Ocgk3hT0cLvS5qKBYAg\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -12468,7 +12571,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": 123\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..-awe55AAvkjymZEpagD4fdSQk0uCGFfjyFwg7upmg_CISWk12JfezKe-N3hjTwYKCSCjScynLGvlH2x4iSgbDg\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": 123\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..-awe55AAvkjymZEpagD4fdSQk0uCGFfjyFwg7upmg_CISWk12JfezKe-N3hjTwYKCSCjScynLGvlH2x4iSgbDg\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -12515,7 +12618,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": null\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..NDwZvVUWw-xG0zU8VsWhiXPWrYycgK_zwN8zZts05DTw23rOTd9IOXQxqhEMzo_X0c25jzowIbpDfEFxqfmnAA\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": null\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..NDwZvVUWw-xG0zU8VsWhiXPWrYycgK_zwN8zZts05DTw23rOTd9IOXQxqhEMzo_X0c25jzowIbpDfEFxqfmnAA\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -12562,7 +12665,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": {\n                \"key\": \"did:example:123\"\n            }\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..y_7VEjN1ENYoedOrj2jsIqgL7FSYelxGgFZD5ckqKvSDM5BVEWiEctD24BWppCndRR7WR9_1ByBm2F1yBSaoCA\"\n        }\n    }\n}",
+											"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": {\n                \"key\": \"did:example:123\"\n            }\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..WJ_K6rlTXdYFhAt5Zmbei9B-5TawMj7h7MwRnKEnJ6pRjHvgBVRwgjrbdpCMs8DtA_SXe5LoVTNIDPSYA8ALCA\"\n        }\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -14689,7 +14792,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Csadnd3P2WqJLxAeXMkyx4nkvXvSEssOQriVuwYK0_6zyssqkkuAcKpkUFh8rf4J5JVpng9yvb_2263dLMLZCw\"\n        }\n    }\n}",
+									"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Csadnd3P2WqJLxAeXMkyx4nkvXvSEssOQriVuwYK0_6zyssqkkuAcKpkUFh8rf4J5JVpng9yvb_2263dLMLZCw\"\n        }\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -14754,7 +14857,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"id\": \"urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded\",\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..mvbcalofPOi7o7nxByyxXCuSOKXuGFM7_W9a8N62-EERarrH4p4T_0c2ZfGnGLiHOvY6Q-dyy38t9HPvXy-MBg\"\n        }\n    }\n}",
+									"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"id\": \"urn:uuid:07aa969e-b40d-4c1b-ab46-ded252003ded\",\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..mvbcalofPOi7o7nxByyxXCuSOKXuGFM7_W9a8N62-EERarrH4p4T_0c2ZfGnGLiHOvY6Q-dyy38t9HPvXy-MBg\"\n        }\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -14819,7 +14922,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": {\n            \"id\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\"\n        },\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Csadnd3P2WqJLxAeXMkyx4nkvXvSEssOQriVuwYK0_6zyssqkkuAcKpkUFh8rf4J5JVpng9yvb_2263dLMLZCw\"\n        }\n    }\n}",
+									"raw": "{\n    \"verifiableCredential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"credentialSubject\": {\n            \"id\": \"did:example:123\"\n        },\n        \"issuanceDate\": \"2006-01-02T15:04:05Z\",\n        \"issuer\": {\n            \"id\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\"\n        },\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"proof\": {\n            \"created\": \"2006-01-02T15:04:05Z\",\n            \"verificationMethod\": \"did:key:z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn#z6MkgVHZNqLBqoQAoGxRiSJP5gLgVEDCJJzT5ZsGEabKtfyn\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"type\": \"Ed25519Signature2018\",\n            \"jws\": \"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Csadnd3P2WqJLxAeXMkyx4nkvXvSEssOQriVuwYK0_6zyssqkkuAcKpkUFh8rf4J5JVpng9yvb_2263dLMLZCw\"\n        }\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -15612,7 +15715,7 @@
 	"variable": [
 		{
 			"key": "responseSchema201CredentialsIssue",
-			"value": "{\"type\":\"object\",\"required\":[\"verifiableCredential\"],\"properties\":{\"verifiableCredential\":{\"title\":\"Serialized Verifiable Credential\",\"oneOf\":[{\"title\":\"Verifiable Credential\",\"type\":\"object\",\"allOf\":[{\"type\":\"object\",\"required\":[\"@context\",\"type\",\"issuer\",\"issuanceDate\",\"credentialSubject\"],\"properties\":{\"@context\":{\"description\":\"This JSON-LD Context defining all terms in the Credential.\",\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"id\":{\"description\":\"The IRI identifying the Credential\",\"type\":\"string\"},\"type\":{\"description\":\"The Type of the Credential\",\"type\":\"array\",\"items\":{\"type\":\"string\"},\"minItems\":1},\"issuer\":{\"description\":\"This value MUST match the assertionMethod used to create the Verifiable Credential.\",\"oneOf\":[{\"type\":\"string\"},{\"type\":\"object\",\"required\":[\"id\"],\"properties\":{\"id\":{\"description\":\"The IRI identifying the Issuer\",\"type\":\"string\"}}}]},\"issuanceDate\":{\"description\":\"This value MUST be an XML Date Time String\",\"type\":\"string\"},\"credentialSubject\":{\"type\":\"object\",\"properties\":{\"id\":{\"description\":\"The IRI identifying the Subject\",\"type\":\"string\"}}}}},{\"type\":\"object\",\"required\":[\"proof\"],\"properties\":{\"proof\":{\"title\":\"Credential Linked Data Proof\",\"allOf\":[{\"title\":\"Linked Data Proof\",\"type\":\"object\",\"description\":\"A JSON-LD Linked Data proof.\",\"required\":[\"type\"],\"properties\":{\"type\":{\"type\":\"string\",\"description\":\"Linked Data Signature Suite used to produce proof.\",\"enum\":[\"Ed25519Signature2018\",\"JsonWebSignature2020\",\"jwt_vc\"]},\"created\":{\"type\":\"string\",\"description\":\"Date the proof was created.\"},\"verificationMethod\":{\"type\":\"string\",\"description\":\"Verification Method used to verify proof.\"},\"jws\":{\"type\":\"string\",\"description\":\"Detached JSON Web Signature\"}}},{\"type\":\"object\",\"properties\":{\"proofPurpose\":{\"type\":\"string\",\"description\":\"Credentials rely on assertionMethod proof purpose.\",\"enum\":[\"assertionMethod\"]}}}]}}}]},{\"title\":\"VC JWT\",\"type\":\"string\"}]}}}",
+			"value": "{\"type\":\"object\",\"required\":[\"verifiableCredential\"],\"properties\":{\"verifiableCredential\":{\"title\":\"Serialized Verifiable Credential\",\"oneOf\":[{\"title\":\"Verifiable Credential\",\"type\":\"object\",\"allOf\":[{\"type\":\"object\",\"required\":[\"@context\",\"type\",\"issuer\",\"issuanceDate\",\"credentialSubject\"],\"properties\":{\"@context\":{\"description\":\"The JSON-LD Context defining all terms in the Credential. This array\\nMUST contain \\\"https://w3id.org/traceability/v1\\\".\\n\",\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"id\":{\"description\":\"The IRI identifying the Credential\",\"type\":\"string\"},\"type\":{\"description\":\"The Type of the Credential\",\"type\":\"array\",\"items\":{\"type\":\"string\"},\"minItems\":1},\"issuer\":{\"description\":\"This value MUST match the assertionMethod used to create the Verifiable Credential.\",\"oneOf\":[{\"type\":\"string\"},{\"type\":\"object\",\"required\":[\"id\"],\"properties\":{\"id\":{\"description\":\"The IRI identifying the Issuer\",\"type\":\"string\"}}}]},\"issuanceDate\":{\"description\":\"This value MUST be an XML Date Time String\",\"type\":\"string\"},\"credentialSubject\":{\"type\":\"object\",\"properties\":{\"id\":{\"description\":\"The IRI identifying the Subject\",\"type\":\"string\"}}}}},{\"type\":\"object\",\"required\":[\"proof\"],\"properties\":{\"proof\":{\"title\":\"Credential Linked Data Proof\",\"allOf\":[{\"title\":\"Linked Data Proof\",\"type\":\"object\",\"description\":\"A JSON-LD Linked Data proof.\",\"required\":[\"type\"],\"properties\":{\"type\":{\"type\":\"string\",\"description\":\"Linked Data Signature Suite used to produce proof.\",\"enum\":[\"Ed25519Signature2018\",\"JsonWebSignature2020\",\"jwt_vc\"]},\"created\":{\"type\":\"string\",\"description\":\"Date the proof was created.\"},\"verificationMethod\":{\"type\":\"string\",\"description\":\"Verification Method used to verify proof.\"},\"jws\":{\"type\":\"string\",\"description\":\"Detached JSON Web Signature\"}}},{\"type\":\"object\",\"properties\":{\"proofPurpose\":{\"type\":\"string\",\"description\":\"Credentials rely on assertionMethod proof purpose.\",\"enum\":[\"assertionMethod\"]}}}]}}}]},{\"title\":\"VC JWT\",\"type\":\"string\"}]}}}",
 			"type": "string"
 		},
 		{

--- a/tests/traceability-v1.jsonld
+++ b/tests/traceability-v1.jsonld
@@ -1,0 +1,4903 @@
+{
+    "@context": {
+      "@version": 1.1,
+      "@vocab": "https://w3id.org/traceability/#undefinedTerm",
+      "AgricultureActivity": {
+        "@context": {
+          "activityDate": {
+            "@id": "https://schema.org/DateTime"
+          },
+          "activityType": {
+            "@id": "https://www.schema.org/value"
+          },
+          "actor": {
+            "@id": "https://w3id.org/traceability#Person"
+          },
+          "agricultureProduct": {
+            "@id": "https://schema.org/ItemList"
+          },
+          "business": {
+            "@id": "https://w3id.org/traceability#dfn-entities"
+          },
+          "location": {
+            "@id": "https://www.gs1.org/voc/Place"
+          },
+          "observation": {
+            "@id": "https://w3id.org/traceability#observation"
+          }
+        },
+        "@id": "https://w3id.org/traceability#AgricultureActivity"
+      },
+      "AgricultureInspectionCommonInfo": {
+        "@context": {
+          "applicant": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#associatedParty"
+          },
+          "delegateOf": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#specifiedOrganization"
+          },
+          "facility": {
+            "@id": "https://www.gs1.org/voc/location"
+          },
+          "inspectionEnded": {
+            "@id": "https://schema.org/endDate"
+          },
+          "inspectionStarted": {
+            "@id": "https://schema.org/startDate"
+          },
+          "inspector": {
+            "@id": "https://w3id.org/traceability#Inspector"
+          },
+          "regulatoryAgency": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#specifiedOrganization"
+          }
+        },
+        "@id": "https://w3id.org/traceability#AgricultureInspectionCommonInfo"
+      },
+      "AgricultureInspectionGeneric": {
+        "@context": {
+          "commonInfo": {
+            "@id": "https://w3id.org/traceability#AgricultureInspectionCommonInfo"
+          },
+          "inspectionType": {
+            "@id": "https://www.schema.org/value"
+          },
+          "name": {
+            "@id": "https://www.schema.org/name"
+          },
+          "observation": {
+            "@id": "https://w3id.org/traceability#observation"
+          },
+          "shipment": {
+            "@id": "https://schema.org/ParcelDelivery"
+          },
+          "status": {
+            "@id": "https://www.schema.org/status"
+          }
+        },
+        "@id": "https://w3id.org/traceability#AgricultureInspectionGeneric"
+      },
+      "AgriculturePackage": {
+        "@context": {
+          "agricultureProduct": {
+            "@id": "https://schema.org/ItemList"
+          },
+          "date": {
+            "@id": "https://schema.org/DateTime"
+          },
+          "grade": {
+            "@id": "https://w3id.org/traceability#grade"
+          },
+          "harvest": {
+            "@id": "https://w3id.org/traceability#AgricultureActivity"
+          },
+          "labelImageHash": {
+            "@id": "https://w3id.org/traceability#labelImageHash"
+          },
+          "labelImageUrl": {
+            "@id": "https://schema.org/url"
+          },
+          "packageName": {
+            "@id": "https://schema.org/name"
+          },
+          "responsibleParty": {
+            "@id": "https://w3id.org/traceability#responsibleParty"
+          },
+          "voicePickCode": {
+            "@id": "https://w3id.org/traceability#voicePickCode"
+          }
+        },
+        "@id": "https://w3id.org/traceability#AgriculturePackage"
+      },
+      "AgricultureParcelDelivery": {
+        "@context": {
+          "agriculturePackage": {
+            "@id": "https://w3id.org/traceability#AgriculturePackage"
+          },
+          "broker": {
+            "@id": "https://schema.org/Organization"
+          },
+          "carrier": {
+            "@id": "https://schema.org/Organization"
+          },
+          "consignee": {
+            "@id": "https://schema.org/Organization"
+          },
+          "deliveryAddress": {
+            "@id": "https://schema.org/deliveryAddress"
+          },
+          "deliveryMethod": {
+            "@id": "https://schema.org/DeliveryMethod"
+          },
+          "expectedArrival": {
+            "@id": "https://schema.org/expectedArrivalFrom"
+          },
+          "foreignPortExport": {
+            "@id": "https://w3id.org/traceability#foreignPortExport"
+          },
+          "movementPoints": {
+            "@id": "https://schema.org/Trip"
+          },
+          "originAddress": {
+            "@id": "https://schema.org/originAddress"
+          },
+          "portOfEntry": {
+            "@id": "https://w3id.org/traceability#portOfEntry"
+          },
+          "purchaser": {
+            "@id": "https://schema.org/Organization"
+          },
+          "shipper": {
+            "@id": "https://schema.org/Organization"
+          },
+          "specialInstructions": {
+            "@id": "https://schema.org/comment"
+          },
+          "trackingNumber": {
+            "@id": "https://schema.org/trackingNumber"
+          }
+        },
+        "@id": "https://w3id.org/traceability#AgricultureParcelDelivery"
+      },
+      "AgricultureProduct": {
+        "@context": {
+          "gtin": {
+            "@id": "https://www.gs1.org/voc/gtin"
+          },
+          "labelImageHash": {
+            "@id": "https://w3id.org/traceability#labelImageHash"
+          },
+          "labelImageUrl": {
+            "@id": "https://schema.org/url"
+          },
+          "name": {
+            "@id": "https://www.schema.org/name"
+          },
+          "plu": {
+            "@id": "https://w3id.org/traceability#plu"
+          },
+          "product": {
+            "@id": "https://www.gs1.org/voc/Product"
+          },
+          "productImageHash": {
+            "@id": "https://w3id.org/traceability#productImageHash"
+          },
+          "productImageUrl": {
+            "@id": "https://schema.org/url"
+          },
+          "scientificName": {
+            "@id": "https://w3id.org/traceability#scientificName"
+          },
+          "upc": {
+            "@id": "https://www.gs1.org/standards/barcodes/ean-upc"
+          }
+        },
+        "@id": "https://w3id.org/traceability#AgricultureProduct"
+      },
+      "BankAccountHolderAffirmation": {
+        "@context": {
+          "affirmingParty": {
+            "@id": "https://w3id.org/traceability#evidenceVerifier"
+          },
+          "bank": {
+            "@id": "https://schema.org/Organization"
+          },
+          "bankAccountHolderAffirmationApproach": {
+            "@id": "https://schema.org/name"
+          }
+        },
+        "@id": "https://w3id.org/traceability#BankAccountHolderAffirmation"
+      },
+      "BillOfLading": {
+        "@context": {
+          "billOfLadingNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Bill_of_lading_number"
+          },
+          "bookingNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Consignment_identifier_carrier_assigned"
+          },
+          "carrier": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#carrierParty"
+          },
+          "consignee": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consigneeParty"
+          },
+          "consignor": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consignorParty"
+          },
+          "freight": {
+            "@id": "https://schema.org/ParcelDelivery"
+          },
+          "freightForwarder": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#freightForwarderParty"
+          },
+          "hazardCode": {
+            "@id": "https://w3id.org/traceability#hazardCode"
+          },
+          "nmfcFreightClass": {
+            "@id": "https://w3id.org/traceability#nmfcFreightClass"
+          },
+          "notify": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#notifyParty"
+          },
+          "portOfDischarge": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl3227/#Place_of_discharge"
+          },
+          "portOfLoading": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl3227/#Place_of_loading"
+          },
+          "relatedDocuments": {
+            "@id": "https://schema.org/Purchase"
+          },
+          "scac": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Standard_Carrier_Alpha_Code_(SCAC)_number"
+          }
+        },
+        "@id": "https://w3id.org/traceability#BillOfLading"
+      },
+      "BillOfLadingCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#BillOfLadingCredential"
+      },
+      "Brand": {
+        "@context": {
+          "logo": {
+            "@id": "https://schema.org/logo"
+          },
+          "url": {
+            "@id": "https://schema.org/url"
+          }
+        },
+        "@id": "https://schema.org/Brand"
+      },
+      "BusinessRegistrationVerification": {
+        "@context": {
+          "affirmingParty": {
+            "@id": "https://w3id.org/traceability#affirmingParty"
+          },
+          "countryOfRegistration": {
+            "@id": "https://schema.org/country"
+          },
+          "registrationUrl": {
+            "@id": "https://schema.org/url"
+          },
+          "taxIdentificationNumber": {
+            "@id": "https://vocabulary.uncefact.org/uncl1153#AHP"
+          }
+        },
+        "@id": "https://w3id.org/traceability#BusinessRegistrationVerification"
+      },
+      "CBP3461ImmediateDeliveryCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#CBP3461ImmediateDeliveryCredential"
+      },
+      "CBP7501EntrySummaryCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#CBP7501EntrySummaryCredential"
+      },
+      "CTPAT": {
+        "@context": {
+          "ctpatAccountNumber": {
+            "@id": "https://w3id.org/traceability#ctpatAccountNumber"
+          },
+          "ctpatMember": {
+            "@id": "https://schema.org/member"
+          },
+          "dateOfLastValidation": {
+            "@id": "https://schema.org/Date"
+          },
+          "issuingCountry": {
+            "@id": "https://schema.org/addressCountry"
+          },
+          "sviNumber": {
+            "@id": "https://w3id.org/traceability#sviNumber"
+          },
+          "tradeSector": {
+            "@id": "https://schema.org/industry"
+          }
+        },
+        "@id": "https://w3id.org/traceability#CTPAT"
+      },
+      "CTPATCertificate": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#CTPATCertificate"
+      },
+      "CTPATEIPApplication": {
+        "@context": {
+          "applicant": {
+            "@id": "https://w3id.org/traceability#applicant"
+          },
+          "applicantType": {
+            "@id": "https://w3id.org/traceability#applicantType"
+          }
+        },
+        "@id": "https://w3id.org/traceability#CTPAT"
+      },
+      "CTPATEIPApplicationCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#CTPATEIPApplicationCredential"
+      },
+      "CTPATEIPFulfillmentCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#CTPATEIPFulfillmentCredential"
+      },
+      "CTPATEIPMarketplaceCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#CTPATEIPMarketplaceCredential"
+      },
+      "CTPATEIPSellerCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#CTPATEIPSellerCredential"
+      },
+      "CargoItem": {
+        "@context": {
+          "cargoLineItems": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/cargoLineItem"
+          },
+          "carrierBookingReference": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#carrierAssignedId"
+          },
+          "numberOfPackages": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageQuantity"
+          },
+          "packageCode": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageTypeCode"
+          },
+          "volume": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#grossVolumeMeasure"
+          },
+          "volumeUnit": {
+            "@id": "https://schema.org/unitCode"
+          },
+          "weight": {
+            "@id": "https://schema.org/weight"
+          },
+          "weightUnit": {
+            "@id": "https://schema.org/unitCode"
+          }
+        },
+        "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/cargoItem"
+      },
+      "CargoLineItem": {
+        "@context": {
+          "HSCode": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/HSCode"
+          },
+          "cargoLineItemID": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/cargoLineItemID"
+          },
+          "descriptionOfGoods": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/descriptionOfGoods"
+          },
+          "shippingMarks": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#physicalShippingMarks"
+          }
+        },
+        "@id": "https://w3id.org/traceability#CargoLineItem"
+      },
+      "CertificationOfOrigin": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#CertificationOfOrigin"
+      },
+      "ChargeDeclaration": {
+        "@context": {
+          "dueAgent": {
+            "@id": "https://schema.org/price"
+          },
+          "dueCarrier": {
+            "@id": "https://schema.org/price"
+          },
+          "tax": {
+            "@id": "https://schema.org/price"
+          },
+          "total": {
+            "@id": "https://schema.org/totalPrice"
+          },
+          "valuationCharge": {
+            "@id": "https://schema.org/price"
+          },
+          "weightCharge": {
+            "@id": "https://schema.org/price"
+          }
+        },
+        "@id": "https://w3id.org/traceability#ChargeDeclaration"
+      },
+      "ChemicalProperty": {
+        "@context": {
+          "description": {
+            "@id": "https://schema.org/description"
+          },
+          "formula": {
+            "@id": "https://purl.obolibrary.org/obo/chebi/formula"
+          },
+          "identifier": {
+            "@id": "https://schema.org/identifier"
+          },
+          "inchi": {
+            "@id": "https://purl.obolibrary.org/obo/chebi/inchi"
+          },
+          "inchikey": {
+            "@id": "https://purl.obolibrary.org/obo/chebi/inchikey"
+          },
+          "name": {
+            "@id": "https://schema.org/name"
+          }
+        },
+        "@id": "https://w3id.org/traceability#ChemicalProperty"
+      },
+      "CommercialInvoiceCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#CommercialInvoiceCredential"
+      },
+      "CommissionEvent": {
+        "@context": {
+          "organization": {
+            "@id": "https://w3id.org/traceability#Organization"
+          },
+          "place": {
+            "@id": "https://schema.org/Place"
+          },
+          "products": {
+            "@id": "https://w3c-ccg.github.io/hashlink/#hl-url-params"
+          }
+        },
+        "@id": "https://w3id.org/traceability#CommissionEvent"
+      },
+      "Commodity": {
+        "@context": {
+          "commodityCode": {
+            "@id": "https://w3id.org/traceability#commodityCode"
+          },
+          "commodityCodeType": {
+            "@id": "https://w3id.org/traceability#commodityCodeType"
+          },
+          "description": {
+            "@id": "https://schema.org/description"
+          }
+        },
+        "@id": "https://w3id.org/traceability#Commodity"
+      },
+      "ConsignmentItem": {
+        "@context": {
+          "commodity": {
+            "@id": "https://w3id.org/traceability#Commodity"
+          },
+          "countryOfOrigin": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#originCountry"
+          },
+          "descriptionOfPackagesAndGoods": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#natureIdentificationCargo"
+          },
+          "grossVolume": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#grossVolumeMeasure"
+          },
+          "grossWeight": {
+            "@id": "https://schema.org/weight"
+          },
+          "manufacturer": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#manufacturerParty"
+          },
+          "marksAndNumbers": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#ShippingMarks"
+          },
+          "netWeight": {
+            "@id": "https://schema.org/weight"
+          },
+          "packageQuantity": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageQuantity"
+          }
+        },
+        "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#ConsignmentItem"
+      },
+      "ConsignmentRatingDetail": {
+        "@context": {
+          "chargeableWeight": {
+            "@id": "https://schema.org/weight"
+          },
+          "commodityItemNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#discountIndicator"
+          },
+          "grossWeight": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#grossWeightMeasure"
+          },
+          "grossWeightUnit": {
+            "@id": "https://schema.org/unitCode"
+          },
+          "natureAndVolumeOfGoods": {
+            "@id": "https://schema.org/description"
+          },
+          "numberOfPieces": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageQuantity"
+          },
+          "rateCharge": {
+            "@id": "https://schema.org/price"
+          },
+          "rateClass": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#freightChargeTariffClassCode"
+          },
+          "total": {
+            "@id": "https://schema.org/totalPrice"
+          }
+        },
+        "@id": "https://w3id.org/traceability#ConsignmentRatingDetail"
+      },
+      "ContactPoint": {
+        "@context": {
+          "email": {
+            "@id": "https://schema.org/email"
+          },
+          "name": {
+            "@id": "https://schema.org/name"
+          },
+          "phoneNumber": {
+            "@id": "https://schema.org/telephone"
+          },
+          "place": {
+            "@id": "https://w3id.org/traceability#place"
+          }
+        },
+        "@id": "https://schema.org/ContactPoint"
+      },
+      "CrudeOilProduct": {
+        "@context": {
+          "HSCode": {
+            "@id": "https://w3id.org/identifier"
+          },
+          "UWI": {
+            "@id": "https://schema.org/identifier"
+          },
+          "facility": {
+            "@id": "https://www.gs1.org/voc/Place"
+          },
+          "observation": {
+            "@id": "https://w3id.org/traceability#observation"
+          },
+          "product": {
+            "@id": "https://www.gs1.org/voc/Product"
+          },
+          "productionDate": {
+            "@id": "https://schema.org/DateTime"
+          }
+        },
+        "@id": "https://w3id.org/traceability#CrudeOilProduct"
+      },
+      "CrudeOilProductCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#CrudeOilProductCredential"
+      },
+      "Customer": {
+        "@context": {
+          "address": {
+            "@id": "https://schema.org/PostalAddress"
+          },
+          "email": {
+            "@id": "https://schema.org/email"
+          },
+          "name": {
+            "@id": "https://schema.org/name"
+          },
+          "telephone": {
+            "@id": "https://schema.org/telephone"
+          }
+        },
+        "@id": "https://w3id.org/traceability#Customer"
+      },
+      "DCSAShippingInstruction": {
+        "@context": {
+          "cargoItems": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#includedConsignmentItem"
+          },
+          "carrierBookingReference": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Consignment_identifier_carrier_assigned"
+          },
+          "consignee": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consigneeParty"
+          },
+          "consigneesFreightForwarder": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#freightForwarderParty"
+          },
+          "firstNotify": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#notifyParty"
+          },
+          "invoicePayableAt": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/invoicePayableAt"
+          },
+          "invoicePayerConsignee": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consigneeParty"
+          },
+          "invoicePayerShipper": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#shipperParty"
+          },
+          "otherNotify": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#notifyParty"
+          },
+          "preCarriageUnderShippersResponsibility": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/preCarriageUnderShippersResponsibility"
+          },
+          "secondNotify": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#notifyParty"
+          },
+          "shipmentLocations": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DOCUMENTATION_DOMAIN/1.0.0#/components/schemas/shipmentLocation"
+          },
+          "shipper": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consignorParty"
+          },
+          "shippersFreightForwarder": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#freightForwarderParty"
+          },
+          "shippingInstructionID": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Transport_instruction_number"
+          },
+          "transportDocumentType": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/transportDocumentType"
+          },
+          "utilizedTransportEquipments": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#utilizedTransportEquipment"
+          }
+        },
+        "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#Instructions"
+      },
+      "DCSAShippingInstructionCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#DCSAShippingInstructionCredential"
+      },
+      "DCSATransportDocument": {
+        "@context": {
+          "cargoMovementTypeAtDestination": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.2#/components/schemas/cargoMovementTypeAtDestination"
+          },
+          "cargoMovementTypeAtOrigin": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.2#/components/schemas/cargoMovementTypeAtOrigin"
+          },
+          "charges": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/charges"
+          },
+          "clauses": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/clauses"
+          },
+          "declaredValueCurrency": {
+            "@id": "https://schema.org/currency"
+          },
+          "issueDate": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#issueDateTime"
+          },
+          "issuerCode": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Standard_Carrier_Alpha_Code_(SCAC)_number"
+          },
+          "issuerCodeListProvider": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.2#/components/schemas/issuerCodeListProvider"
+          },
+          "placeOfIssue": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#issueLocation"
+          },
+          "receiptDeliveryTypeAtDestination": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.2#/components/schemas/receiptDeliveryTypeAtDestination"
+          },
+          "receiptDeliveryTypeAtOrigin": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.2#/components/schemas/receiptDeliveryTypeAtOrigin"
+          },
+          "receivedForShipmentDate": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#availabilityDueDateTime"
+          },
+          "serviceContractReference": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.2#/components/schemas/serviceContractReference"
+          },
+          "shippedOnBoardDate": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.2#/components/schemas/shippedOnBoardDate"
+          },
+          "shippingInstruction": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/shippingInstruction"
+          },
+          "termsAndConditions": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#termsAndConditionsDescription"
+          },
+          "transportDocumentReference": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Bill_of_lading_number"
+          },
+          "transports": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/transports"
+          }
+        },
+        "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/transportDocument"
+      },
+      "DCSATransportDocumentCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#DCSATransportDocumentCredential"
+      },
+      "DeMinimisShipment": {
+        "@context": {
+          "buyer": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#buyerParty"
+          },
+          "enhancedProductDescription": {
+            "@id": "https://w3id.org/traceability#enhancedProductDescription"
+          },
+          "finalDeliverTo": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#shipToParty"
+          },
+          "houseBillOfLadingNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#House_bill_of_lading_number"
+          },
+          "knownCarrierCustomerFlag": {
+            "@id": "https://w3id.org/traceability#knownCarrierCustomerFlag"
+          },
+          "knownMarketplaceSellerFlag": {
+            "@id": "https://w3id.org/traceability#knownMarketplaceSellerFlag"
+          },
+          "listedPriceOnMarketplace": {
+            "@id": "https://schema.org/price"
+          },
+          "marketplaceSellerAccountNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Account_number"
+          },
+          "masterBillOfLadingNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Bill_of_lading_number"
+          },
+          "modeOfTransportation": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#mode"
+          },
+          "originatorCode": {
+            "@id": "https://w3id.org/traceability#originatorCode"
+          },
+          "participantFilerType": {
+            "@id": "https://w3id.org/traceability#participantFilerType"
+          },
+          "productPicture": {
+            "@id": "https://schema.org/image"
+          },
+          "seller": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#sellerParty"
+          },
+          "shipmentInitiator": {
+            "@id": "https://w3id.org/traceability#shipmentInitiator"
+          },
+          "shipmentSecurityScan": {
+            "@id": "https://w3id.org/traceability#shipmentSecurityScan"
+          },
+          "shipmentTrackingNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#shipmentIdentificationId"
+          }
+        },
+        "@id": "https://w3id.org/traceability#DeMinimisShipment"
+      },
+      "DeMinimisShipmentCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#DeMinimisExemptionCertificate"
+      },
+      "DeliverySchedule": {
+        "@context": {
+          "batchNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#batchIdentificationId"
+          },
+          "commodity": {
+            "@id": "https://w3id.org/traceability#Commodity"
+          },
+          "consignee": {
+            "@id": "https://schema.org/Organization"
+          },
+          "consignor": {
+            "@id": "https://schema.org/Organization"
+          },
+          "deliveryDate": {
+            "@id": "https://schema.org/arrivalTime"
+          },
+          "injectionDate": {
+            "@id": "https://schema.org/departureTime"
+          },
+          "injectionVolume": {
+            "@id": "https://schema.org/Quantity"
+          },
+          "place": {
+            "@id": "https://schema.org/Place"
+          },
+          "transporter": {
+            "@id": "https://schema.org/Organization"
+          }
+        },
+        "@id": "https://w3id.org/traceability#DeliverySchedule"
+      },
+      "EDDShape": {
+        "@context": {
+          "abundance": {
+            "@id": "https://schema.org/description"
+          },
+          "approximateQuantity": {
+            "@id": "http://rs.tdwg.org/dwc/terms/organismQuantity"
+          },
+          "centroidType": {
+            "@id": "https://schema.org/polygon"
+          },
+          "commonName": {
+            "@id": "http://rs.tdwg.org/dwc/terms/vernacularName"
+          },
+          "coordinateUncertainty": {
+            "@id": "http://rs.tdwg.org/dwc/terms/coordinateUncertaintyInMeters"
+          },
+          "dateEntered": {
+            "@id": "http://rs.tdwg.org/dwc/terms/eventDate"
+          },
+          "dateUncertaintyDays": {
+            "@id": "https://schema.org/value"
+          },
+          "dateUpdated": {
+            "@id": "http://rs.tdwg.org/dwc/terms/eventDate"
+          },
+          "density": {
+            "@id": "http://rs.tdwg.org/dwc/terms/measurementRemarks"
+          },
+          "grossAreaAcres": {
+            "@id": "http://rs.tdwg.org/dwc/terms/measurementValue"
+          },
+          "habitat": {
+            "@id": "http://rs.tdwg.org/dwc/terms/habitat"
+          },
+          "identificationCredibility": {
+            "@id": "http://rs.tdwg.org/dwc/terms/identificationRemarks"
+          },
+          "incidence": {
+            "@id": "http://rs.tdwg.org/dwc/terms/measurementValue"
+          },
+          "infestedAreaAcres": {
+            "@id": "http://rs.tdwg.org/dwc/terms/measurementValue"
+          },
+          "location": {
+            "@id": "https://schema.org/location"
+          },
+          "managementStatus": {
+            "@id": "https://schema.org/status"
+          },
+          "mapResources": {
+            "@id": "https://w3id.org/traceability#MapResource"
+          },
+          "meta": {
+            "@id": "https://w3id.org/traceability#EDDShapeMeta"
+          },
+          "naDatum": {
+            "@id": "http://rs.tdwg.org/dwc/terms/geodeticDatum"
+          },
+          "observationDate": {
+            "@id": "http://rs.tdwg.org/dwc/terms/eventDate"
+          },
+          "occurrenceStatus": {
+            "@id": "https://schema.org/value"
+          },
+          "percentCover": {
+            "@id": "http://rs.tdwg.org/dwc/terms/measurementValue"
+          },
+          "persistentId": {
+            "@id": "http://rs.tdwg.org/dwc/terms/occurrenceID"
+          },
+          "quantity": {
+            "@id": "http://rs.tdwg.org/dwc/terms/organismQuantity"
+          },
+          "quantityUnits": {
+            "@id": "http://rs.tdwg.org/dwc/terms/organismQuantityType"
+          },
+          "recordBasis": {
+            "@id": "http://rs.tdwg.org/dwc/terms/samplingProtocol"
+          },
+          "reporter": {
+            "@id": "https://schema.org/name"
+          },
+          "reviewer": {
+            "@id": "http://rs.tdwg.org/dwc/terms/identifiedBy"
+          },
+          "scientificName": {
+            "@id": "http://rs.tdwg.org/dwc/terms/scientificName"
+          },
+          "severity": {
+            "@id": "http://rs.tdwg.org/dwc/terms/measurementValue"
+          },
+          "siteName": {
+            "@id": "http://rs.tdwg.org/dwc/terms/locationID"
+          },
+          "status": {
+            "@id": "https://schema.org/description"
+          },
+          "subjectNativity": {
+            "@id": "http://rs.tdwg.org/dwc/terms/establishmentMeans"
+          },
+          "surveyor": {
+            "@id": "http://rs.tdwg.org/dwc/terms/recordedBy"
+          },
+          "uuid": {
+            "@id": "http://rs.tdwg.org/dwc/terms/dateIdentified"
+          },
+          "verificationMethod": {
+            "@id": "http://rs.tdwg.org/dwc/terms/identificationRemarks"
+          },
+          "verified": {
+            "@id": "http://rs.tdwg.org/dwc/terms/identificationVerificationStatus"
+          },
+          "visitType": {
+            "@id": "https://schema.org/description"
+          }
+        },
+        "@id": "https://w3id.org/traceability#EDDShape"
+      },
+      "EDDShapeMeta": {
+        "@context": {
+          "collectionTimeMinutes": {
+            "@id": "https://schema.org/activityDuration"
+          },
+          "comments": {
+            "@id": "http://rs.tdwg.org/dwc/terms/eventRemarks"
+          },
+          "dataCollectionMethod": {
+            "@id": "http://rs.tdwg.org/dwc/terms/measurementMethod"
+          },
+          "hostDamage": {
+            "@id": "https://schema.org/description"
+          },
+          "hostName": {
+            "@id": "http://rs.tdwg.org/dwc/terms/vernacularName"
+          },
+          "hostPhenology": {
+            "@id": "http://rs.tdwg.org/dwc/terms/lifeStage"
+          },
+          "hostScientificName": {
+            "@id": "http://rs.tdwg.org/dwc/terms/scientificName"
+          },
+          "largestOrganismSampled": {
+            "@id": "https://schema.org/size"
+          },
+          "lifeStatus": {
+            "@id": "http://rs.tdwg.org/dwc/terms/occurrenceRemarks"
+          },
+          "localOwnership": {
+            "@id": "http://rs.tdwg.org/dwc/terms/locality"
+          },
+          "locality": {
+            "@id": "http://rs.tdwg.org/dwc/terms/locationRemarks"
+          },
+          "method": {
+            "@id": "http://rs.tdwg.org/dwc/terms/locationRemarks"
+          },
+          "museum": {
+            "@id": "https://schema.org/name"
+          },
+          "museumRecord": {
+            "@id": "http://rs.tdwg.org/dwc/terms/catalogNumber"
+          },
+          "numberCollected": {
+            "@id": "http://rs.tdwg.org/dwc/terms/measurementRemarks"
+          },
+          "numberTraps": {
+            "@id": "http://rs.tdwg.org/dwc/terms/samplingEffort"
+          },
+          "observationId": {
+            "@id": "http://rs.tdwg.org/dwc/terms/identifiedBy"
+          },
+          "originalRecordId": {
+            "@id": "http://rs.tdwg.org/dwc/terms/recordNumber"
+          },
+          "originalReportedName": {
+            "@id": "http://rs.tdwg.org/dwc/terms/verbatimIdentification"
+          },
+          "phenology": {
+            "@id": "http://rs.tdwg.org/dwc/terms/organismRemarks"
+          },
+          "plantsTreated": {
+            "@id": "http://rs.tdwg.org/dwc/terms/organismQuantity"
+          },
+          "populationStatus": {
+            "@id": "http://rs.tdwg.org/dwc/terms/degreeOfEstablishment"
+          },
+          "publicReviewerComments": {
+            "@id": "http://rs.tdwg.org/dwc/terms/identificationRemarks"
+          },
+          "recordOwner": {
+            "@id": "https://schema.org/name"
+          },
+          "recordSourceType": {
+            "@id": "http://rs.tdwg.org/dwc/terms/measurementRemarks"
+          },
+          "reference": {
+            "@id": "http://rs.tdwg.org/dwc/terms/associatedReferences"
+          },
+          "sex": {
+            "@id": "http://rs.tdwg.org/dwc/terms/sex"
+          },
+          "shapeType": {
+            "@id": "https://schema.org/description"
+          },
+          "smallestOrganismSampled": {
+            "@id": "https://schema.org/size"
+          },
+          "substrate": {
+            "@id": "http://rs.tdwg.org/dwc/terms/occurrenceRemarks"
+          },
+          "targetCount": {
+            "@id": "http://rs.tdwg.org/dwc/terms/organismQuantity"
+          },
+          "targetName": {
+            "@id": "http://rs.tdwg.org/dwc/terms/organismName"
+          },
+          "targetRange": {
+            "@id": "http://rs.tdwg.org/dwc/terms/organismQuantity"
+          },
+          "trapType": {
+            "@id": "http://rs.tdwg.org/dwc/terms/samplingProtocol"
+          },
+          "treatmentArea": {
+            "@id": "https://schema.org/value"
+          },
+          "treatmentComments": {
+            "@id": "http://rs.tdwg.org/dwc/terms/eventRemarks"
+          },
+          "voucher": {
+            "@id": "http://rs.tdwg.org/dwc/terms/disposition"
+          },
+          "waterBodyName": {
+            "@id": "http://rs.tdwg.org/dwc/terms/waterBody"
+          },
+          "waterBodyType": {
+            "@id": "http://rs.tdwg.org/dwc/terms/occurrenceRemarks"
+          }
+        },
+        "@id": "https://w3id.org/traceability#EDDShapeMeta"
+      },
+      "Entity": {
+        "@context": {
+          "address": {
+            "@id": "https://schema.org/PostalAddress"
+          },
+          "email": {
+            "@id": "https://schema.org/email"
+          },
+          "entityType": {
+            "@id": "https://schema.org/additionalType"
+          },
+          "faxNumber": {
+            "@id": "https://schema.org/faxNumber"
+          },
+          "legalName": {
+            "@id": "https://schema.org/legalName"
+          },
+          "name": {
+            "@id": "https://schema.org/name"
+          },
+          "phoneNumber": {
+            "@id": "https://schema.org/telephone"
+          },
+          "taxId": {
+            "@id": "https://schema.org/taxID"
+          },
+          "url": {
+            "@id": "https://schema.org/url"
+          }
+        },
+        "@id": "https://w3id.org/traceability#Entity"
+      },
+      "EntrySummary": {
+        "@context": {
+          "billOfLadingNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Bill_of_lading_number"
+          },
+          "bondType": {
+            "@id": "https://w3id.org/traceability#bondType"
+          },
+          "consigneeNumber": {
+            "@id": "https://schema.org/identifier"
+          },
+          "countryOfOrigin": {
+            "@id": "https://w3id.org/traceability#countryOfOrigin"
+          },
+          "declarationOfImporter": {
+            "@id": "https://w3id.org/traceability#declarationOfImporter"
+          },
+          "descriptionOfMerchandise": {
+            "@id": "https://w3id.org/traceability#descriptionOfMerchandise"
+          },
+          "duty": {
+            "@id": "https://schema.org/MonetaryAmount"
+          },
+          "entryDate": {
+            "@id": "https://schema.org/Date"
+          },
+          "entryNumber": {
+            "@id": "https://schema.org/identifier"
+          },
+          "entryType": {
+            "@id": "https://w3id.org/traceability#entryType"
+          },
+          "exportDate": {
+            "@id": "https://schema.org/Date"
+          },
+          "exportingCountry": {
+            "@id": "https://schema.org/addressCountry"
+          },
+          "immediateTransportationDate": {
+            "@id": "https://schema.org/Date"
+          },
+          "immediateTransportationNumber": {
+            "@id": "https://schema.org/identifier"
+          },
+          "importDate": {
+            "@id": "https://schema.org/Date"
+          },
+          "importerNumber": {
+            "@id": "https://schema.org/identifier"
+          },
+          "importerOfRecord": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#importerParty"
+          },
+          "importingCarrier": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#carrierParty"
+          },
+          "locationOfGoods": {
+            "@id": "https://schema.org/Place"
+          },
+          "manufacturerId": {
+            "@id": "https://schema.org/identifier"
+          },
+          "missingDocuments": {
+            "@id": "https://w3id.org/traceability#missingDocuments"
+          },
+          "other": {
+            "@id": "https://schema.org/MonetaryAmount"
+          },
+          "otherFeeSummary": {
+            "@id": "https://w3id.org/traceability#otherFeeSummary"
+          },
+          "portCode": {
+            "@id": "https://schema.org/Place"
+          },
+          "portOfLoading": {
+            "@id": "https://schema.org/Place"
+          },
+          "portOfUnlading": {
+            "@id": "https://schema.org/Place"
+          },
+          "referenceNumber": {
+            "@id": "https://w3id.org/traceability#referenceNumber"
+          },
+          "summaryDate": {
+            "@id": "https://schema.org/Date"
+          },
+          "suretyCode": {
+            "@id": "https://w3id.org/traceability#suretyCode"
+          },
+          "tax": {
+            "@id": "https://schema.org/MonetaryAmount"
+          },
+          "total": {
+            "@id": "https://schema.org/MonetaryAmount"
+          },
+          "totalEnteredValue": {
+            "@id": "https://schema.org/MonetaryAmount"
+          },
+          "transportMode": {
+            "@id": "https://w3id.org/traceability#transportMode"
+          },
+          "ultimateConsignee": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#shipToParty"
+          }
+        },
+        "@id": "https://w3id.org/traceability#EntrySummary"
+      },
+      "EntrySummaryLineItem": {
+        "@context": {
+          "adCvdNumber": {
+            "@id": "https://w3id.org/traceability#adCvdNumber"
+          },
+          "adCvdRate": {
+            "@id": "https://w3id.org/traceability#adCvdRate"
+          },
+          "agriculturalLicenseNumber": {
+            "@id": "https://w3id.org/traceability#agriculturalLicenseNumber"
+          },
+          "categoryNumber": {
+            "@id": "https://w3id.org/traceability#categoryNumber"
+          },
+          "charges": {
+            "@id": "https://schema.org/MonetaryAmount"
+          },
+          "commodity": {
+            "@id": "https://w3id.org/traceability#Commodity"
+          },
+          "dutyAndIRTax": {
+            "@id": "https://w3id.org/traceability#dutyAndIRTax"
+          },
+          "enteredValue": {
+            "@id": "https://schema.org/MonetaryAmount"
+          },
+          "grossWeight": {
+            "@id": "https://schema.org/weight"
+          },
+          "htsRate": {
+            "@id": "https://w3id.org/traceability#htsRate"
+          },
+          "ircRate": {
+            "@id": "https://w3id.org/traceability#ircRate"
+          },
+          "manifestQuantity": {
+            "@id": "https://w3id.org/traceability#manifestQuantity"
+          },
+          "netQuantity": {
+            "@id": "https://schema.org/Quantity"
+          },
+          "otherFees": {
+            "@id": "https://w3id.org/traceability#otherFees"
+          },
+          "relationship": {
+            "@id": "https://schema.org/MonetaryAmount"
+          },
+          "visaNumber": {
+            "@id": "https://w3id.org/traceability#visaNumber"
+          }
+        },
+        "@id": "https://w3id.org/traceability#EntrySummaryLineItem"
+      },
+      "Event": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#EventCredential"
+      },
+      "ExternalResource": {
+        "@context": {
+          "hash": {
+            "@id": "https://schema.org/sha256"
+          },
+          "uri": {
+            "@id": "https://schema.org/contentUrl"
+          }
+        },
+        "@id": "https://w3id.org/traceability#ExternalResource"
+      },
+      "FSMAAbstractKDE": {
+        "@context": {
+          "name": {
+            "@id": "https://schema.org/propertyID"
+          },
+          "value": {
+            "@id": "https://schema.org/value"
+          }
+        },
+        "@id": "https://w3id.org/traceability#FSMAAbstractKDE"
+      },
+      "FSMACreatingCTE": {
+        "@context": {
+          "additionalData": {
+            "@id": "https://w3id.org/traceability#FSMAAbstractKDE"
+          },
+          "dateCompleted": {
+            "@id": "https://schema.org/endDate"
+          },
+          "food": {
+            "@id": "https://w3id.org/traceability#FSMAProduct"
+          },
+          "location": {
+            "@id": "https://schema.org/location"
+          }
+        },
+        "@id": "https://w3id.org/traceability#FSMACreatingCTE"
+      },
+      "FSMACreatingCTECredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#FSMACreatingCTECredential"
+      },
+      "FSMAFirstReceiverData": {
+        "@context": {
+          "additionalData": {
+            "@id": "https://w3id.org/traceability#FSMAAbstractKDE"
+          },
+          "coolingDate": {
+            "@id": "https://schema.org/endDate"
+          },
+          "coolingLocation": {
+            "@id": "https://schema.org/location"
+          },
+          "harvestDate": {
+            "@id": "https://schema.org/endDate"
+          },
+          "originatorLocation": {
+            "@id": "https://schema.org/location"
+          },
+          "packingDate": {
+            "@id": "https://schema.org/endDate"
+          },
+          "packingLocation": {
+            "@id": "https://schema.org/location"
+          },
+          "traceabilityLot": {
+            "@id": "https://w3id.org/traceability#FSMATraceabilityLot"
+          }
+        },
+        "@id": "https://w3id.org/traceability#FSMAFirstReceiverData"
+      },
+      "FSMAFirstReceiverDataCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#FSMAFirstReceiverDataCredential"
+      },
+      "FSMAGrowingCTE": {
+        "@context": {
+          "additionalData": {
+            "@id": "https://w3id.org/traceability#FSMAAbstractKDE"
+          },
+          "growingAreaCoordinates": {
+            "@id": "https://w3id.org/traceability#GeoCoordinates"
+          },
+          "traceabilityLot": {
+            "@id": "https://w3id.org/traceability#FSMATraceabilityLot"
+          }
+        },
+        "@id": "https://w3id.org/traceability#FSMAGrowingCTE"
+      },
+      "FSMAGrowingCTECredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#FSMAGrowingCTECredential"
+      },
+      "FSMAProduct": {
+        "@context": {
+          "additionalData": {
+            "@id": "https://w3id.org/traceability#FSMAAbstractKDE"
+          },
+          "quantity": {
+            "@id": "https://schema.org/value"
+          },
+          "traceabilityLot": {
+            "@id": "https://w3id.org/traceability#FSMATraceabilityLot"
+          },
+          "unit": {
+            "@id": "https://schema.org/unitText"
+          }
+        },
+        "@id": "https://w3id.org/traceability#FSMAProduct"
+      },
+      "FSMAReceivingCTE": {
+        "@context": {
+          "additionalData": {
+            "@id": "https://w3id.org/traceability#FSMAAbstractKDE"
+          },
+          "dateReceived": {
+            "@id": "https://schema.org/endDate"
+          },
+          "shipment": {
+            "@id": "https://w3id.org/traceability#FSMAShipment"
+          }
+        },
+        "@id": "https://w3id.org/traceability#FSMAReceivingCTE"
+      },
+      "FSMAReceivingCTECredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#FSMAReceivingCTECredential"
+      },
+      "FSMAShipment": {
+        "@context": {
+          "additionalData": {
+            "@id": "https://w3id.org/traceability#FSMAAbstractKDE"
+          },
+          "from": {
+            "@id": "https://schema.org/fromLocation"
+          },
+          "product": {
+            "@id": "https://w3id.org/traceability#FSMAProduct"
+          },
+          "to": {
+            "@id": "https://schema.org/toLocation"
+          }
+        },
+        "@id": "https://w3id.org/traceability#FSMAShipment"
+      },
+      "FSMAShippingCTE": {
+        "@context": {
+          "additionalData": {
+            "@id": "https://w3id.org/traceability#FSMAAbstractKDE"
+          },
+          "dateShipped": {
+            "@id": "https://schema.org/startDate"
+          },
+          "shipment": {
+            "@id": "https://w3id.org/traceability#FSMAShipment"
+          }
+        },
+        "@id": "https://w3id.org/traceability#FSMAShippingCTE"
+      },
+      "FSMAShippingCTECredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#FSMAShippingCTECredential"
+      },
+      "FSMATraceabilityLot": {
+        "@context": {
+          "additionalData": {
+            "@id": "https://w3id.org/traceability#FSMAAbstractKDE"
+          },
+          "lotCode": {
+            "@id": "https://www.gs1.org/voc/hasBatchLotNumber"
+          },
+          "lotCodeAssignmentMethod": {
+            "@id": "https://schema.org/description"
+          },
+          "lotCodeGeneratorLocation": {
+            "@id": "https://schema.org/location"
+          },
+          "lotCodeGeneratorPOC": {
+            "@id": "https://schema.org/contactPoint"
+          },
+          "lotType": {
+            "@id": "https://schema.org/additionalType"
+          }
+        },
+        "@id": "https://w3id.org/traceability#FSMATraceabilityLot"
+      },
+      "FSMATransformingCTE": {
+        "@context": {
+          "additionalData": {
+            "@id": "https://w3id.org/traceability#FSMAAbstractKDE"
+          },
+          "dateCompleted": {
+            "@id": "https://schema.org/endDate"
+          },
+          "foodProduced": {
+            "@id": "https://w3id.org/traceability#FSMAProduct"
+          },
+          "foodUsed": {
+            "@id": "https://w3id.org/traceability#FSMAProduct"
+          },
+          "locationTransformed": {
+            "@id": "https://schema.org/location"
+          }
+        },
+        "@id": "https://w3id.org/traceability#FSMATransformingCTE"
+      },
+      "FSMATransformingCTECredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#FSMATransformingCTECredential"
+      },
+      "FoodDefenseDeficiency": {
+        "@context": {
+          "dateCorrected": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#occurrenceDateTime"
+          },
+          "description": {
+            "@id": "https://schema.org/description"
+          },
+          "number": {
+            "@id": "https://schema.org/identifier"
+          },
+          "proposedCorrectionDate": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#occurrenceDateTime"
+          }
+        },
+        "@id": "https://w3id.org/traceability#FoodDefenseDeficiency"
+      },
+      "FoodDefenseInspection": {
+        "@context": {
+          "commonInfo": {
+            "@id": "https://w3id.org/traceability#AgricultureInspectionCommonInfo"
+          },
+          "deficiencies": {
+            "@id": "https://w3id.org/traceability#FoodDefenseDeficiency"
+          },
+          "questions": {
+            "@id": "https://w3id.org/traceability#FoodDefenseQuestion"
+          }
+        },
+        "@id": "https://w3id.org/traceability#FoodDefenseInspection"
+      },
+      "FoodDefenseInspectionCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#FoodDefenseInspectionCredential"
+      },
+      "FoodDefenseQuestion": {
+        "@context": {
+          "facility": {
+            "@id": "https://schema.org/location"
+          },
+          "number": {
+            "@id": "https://schema.org/identifier"
+          },
+          "rating": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#assertion"
+          },
+          "response": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#assertion"
+          }
+        },
+        "@id": "https://w3id.org/traceability#FoodDefenseQuestion"
+      },
+      "FoodGradeInspection": {
+        "@context": {
+          "carrierTypeName": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#utilizedTransportEquipment"
+          },
+          "commonInfo": {
+            "@id": "https://w3id.org/traceability#AgricultureInspectionCommonInfo"
+          },
+          "doorsOpen": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#reportedStatus"
+          },
+          "estimatedCharges": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#applicableServiceCharge"
+          },
+          "generalRemarks": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#remarks"
+          },
+          "loadingStatus": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#reportedStatus"
+          },
+          "lots": {
+            "@id": "https://w3id.org/traceability#FoodGradeInspectionLot"
+          },
+          "refrigerationUnitOn": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#reportedStatus"
+          },
+          "shipment": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#transportPackage"
+          }
+        },
+        "@id": "https://w3id.org/traceability#FoodGradeInspection"
+      },
+      "FoodGradeInspectionCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#FoodGradeInspectionCredential"
+      },
+      "FoodGradeInspectionDefect": {
+        "@context": {
+          "averageDefects": {
+            "@id": "https://qudt.org/vocab/unit/PERCENT"
+          },
+          "damage": {
+            "@id": "https://qudt.org/vocab/unit/PERCENT"
+          },
+          "offsizeDefect": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#damageRemarks"
+          },
+          "seriousDamage": {
+            "@id": "https://qudt.org/vocab/unit/PERCENT"
+          },
+          "verySeriousDamage": {
+            "@id": "https://qudt.org/vocab/unit/PERCENT"
+          }
+        },
+        "@id": "https://w3id.org/traceability#FoodGradeInspectionDefect"
+      },
+      "FoodGradeInspectionLot": {
+        "@context": {
+          "agricultureProduct": {
+            "@id": "https://w3id.org/traceability#AgricultureProduct"
+          },
+          "brandMarkings": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#brandName"
+          },
+          "countInspected": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#remark"
+          },
+          "defects": {
+            "@id": "https://w3id.org/traceability#FoodGradeInspectionDefect"
+          },
+          "grade": {
+            "@id": "https://w3id.org/traceability#FoodGradeInspectionResult"
+          },
+          "lotIdentifier": {
+            "@id": "https://www.gs1.org/voc/hasBatchLotNumber"
+          },
+          "maxTemperature": {
+            "@id": "https://schema.org/measuredValue"
+          },
+          "minTemperature": {
+            "@id": "https://schema.org/measuredValue"
+          },
+          "numberContainers": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageQuantity"
+          },
+          "remarks": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#remark"
+          },
+          "samples": {
+            "@id": "https://w3id.org/traceability#FoodGradeInspectionSample"
+          }
+        },
+        "@id": "https://w3id.org/traceability#FoodGradeInspectionLot"
+      },
+      "FoodGradeInspectionResult": {
+        "@context": {
+          "details": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#additionalInformationNote"
+          },
+          "gradeInspected": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#standard"
+          },
+          "requirementsMet": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#assertion"
+          }
+        },
+        "@id": "https://w3id.org/traceability#FoodGradeInspectionResult"
+      },
+      "FoodGradeInspectionSample": {
+        "@context": {
+          "sampleProperties": {
+            "@id": "https://w3id.org/traceability#FoodGradeInspectionSampleProperty"
+          },
+          "sampleSizeUnits": {
+            "@id": "https://schema.org/unitText"
+          },
+          "sampleSizeValue": {
+            "@id": "https://schema.org/value"
+          }
+        },
+        "@id": "https://w3id.org/traceability#FoodGradeInspectionSample"
+      },
+      "FoodGradeInspectionSampleProperty": {
+        "@context": {
+          "propertyName": {
+            "@id": "https://schema.org/name"
+          },
+          "propertyValue": {
+            "@id": "https://schema.org/value"
+          }
+        },
+        "@id": "https://w3id.org/traceability#FoodGradeInspectionSampleProperty"
+      },
+      "ForeignChargeDeclaration": {
+        "@context": {
+          "foreignCharges": {
+            "@id": "https://schema.org/price"
+          },
+          "foreignChargesCurrency": {
+            "@id": "https://schema.org/currency"
+          },
+          "foreignCurrencyConvertionRate": {
+            "@id": "https://schema.org/currentExchangeRate"
+          }
+        },
+        "@id": "https://w3id.org/traceability#ForeignChargeDeclaration"
+      },
+      "FreightManifest": {
+        "@context": {
+          "billsOfLading": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#manifestRelatedDocument"
+          },
+          "carrier": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#carrierParty"
+          },
+          "carrierCode": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Standard_Carrier_Alpha_Code_(SCAC)_number"
+          },
+          "transportMeans": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#transportMeans"
+          },
+          "transportMeansId": {
+            "@id": "https://schema.org/identifier"
+          },
+          "voyage": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#TransportMovement"
+          }
+        },
+        "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#manifestRelatedDocument"
+      },
+      "FreightManifestCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#FreightManifestCredential"
+      },
+      "FulfillmentRegistrationCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#FulfillmentRegistrationCredential"
+      },
+      "GAPCorrectiveActionReport": {
+        "@context": {
+          "affirmingRepresentative": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#associatedParty"
+          },
+          "correctiveAction": {
+            "@id": "https://schema.org/potentialAction"
+          },
+          "nonconformityDescription": {
+            "@id": "https://schema.org/description"
+          },
+          "notifiedCompanyStaff": {
+            "@id": "https://schema.org/actionStatus"
+          }
+        },
+        "@id": "https://w3id.org/traceability#GAPCorrectiveActionReport"
+      },
+      "GAPInspection": {
+        "@context": {
+          "GAPPlus": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#documentTypeCode"
+          },
+          "additionalComments": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#remarks"
+          },
+          "commoditiesCovered": {
+            "@id": "https://schema.org/ItemList"
+          },
+          "commoditiesProduced": {
+            "@id": "https://schema.org/ItemList"
+          },
+          "commonInfo": {
+            "@id": "https://w3id.org/traceability#AgricultureInspectionCommonInfo"
+          },
+          "dateReviewed": {
+            "@id": "https://www.gs1.org/voc/certificationAuditDate"
+          },
+          "distributeTo": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#associatedParty"
+          },
+          "fieldOpsHarvestingScope": {
+            "@id": "https://www.gs1.org/voc/certificationStatement"
+          },
+          "harvestCompany": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#associatedParty"
+          },
+          "logoUseScope": {
+            "@id": "https://www.gs1.org/voc/certificationStatement"
+          },
+          "meetsCriteria": {
+            "@id": "https://www.gs1.org/voc/certificationStatus"
+          },
+          "operationDescription": {
+            "@id": "https://schema.org/description"
+          },
+          "otherContractors": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#associatedParty"
+          },
+          "personsInterviewed": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#associatedParty"
+          },
+          "postHarvestOpsScope": {
+            "@id": "https://www.gs1.org/voc/certificationStatement"
+          },
+          "requestedBy": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#associatedParty"
+          },
+          "requirementResults": {
+            "@id": "https://w3id.org/traceability#GAPRequirementResult"
+          },
+          "reviewingOfficial": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#associatedParty"
+          },
+          "subjectToRule": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#regulationConformityId"
+          },
+          "tomatoGreenhouseScope": {
+            "@id": "https://www.gs1.org/voc/certificationStatement"
+          },
+          "tomatoPackingDistributionScope": {
+            "@id": "https://www.gs1.org/voc/certificationStatement"
+          },
+          "tomatoPackinghouseScope": {
+            "@id": "https://www.gs1.org/voc/certificationStatement"
+          },
+          "tomatoProdHarvestingScope": {
+            "@id": "https://www.gs1.org/voc/certificationStatement"
+          },
+          "totalArea": {
+            "@id": "https://www.gs1.org/voc/grossArea"
+          },
+          "usesLogo": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#assertion"
+          }
+        },
+        "@id": "https://w3id.org/traceability#GAPInspection"
+      },
+      "GAPInspectionCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#GAPInspectionCredential"
+      },
+      "GAPLocationCertification": {
+        "@context": {
+          "gapInspection": {
+            "@id": "https://www.gs1.org/voc/certification"
+          },
+          "isCertified": {
+            "@id": "https://www.gs1.org/voc/certificationStatus"
+          },
+          "location": {
+            "@id": "https://www.gs1.org/voc/certificationSubject"
+          }
+        },
+        "@id": "https://w3id.org/traceability#GAPLocationCertification"
+      },
+      "GAPRequirementResult": {
+        "@context": {
+          "auditorComments": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#remarks"
+          },
+          "correctiveActionReport": {
+            "@id": "https://w3id.org/traceability#GAPCorrectiveActionReport"
+          },
+          "requirementNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#standard"
+          },
+          "resultCode": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#assertionCode"
+          }
+        },
+        "@id": "https://w3id.org/traceability#GAPRequirementResult"
+      },
+      "GS1CompanyPrefixLicenceCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#GS1CompanyPrefixLicenceCredential"
+      },
+      "GS1PrefixLicenceCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#GS1PrefixLicenceCredential"
+      },
+      "GeoCoordinates": {
+        "@context": {
+          "latitude": {
+            "@id": "https://schema.org/latitude"
+          },
+          "longitude": {
+            "@id": "https://schema.org/longitude"
+          }
+        },
+        "@id": "https://schema.org/GeoCoordinates"
+      },
+      "HouseBillOfLading": {
+        "@context": {
+          "billOfLadingNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Bill_of_lading_number"
+          },
+          "bookingNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#carrierAssignedId"
+          },
+          "carrier": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#carrierParty"
+          },
+          "consignee": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consigneeParty"
+          },
+          "declaredValue": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#declaredValueForCarriageAmount"
+          },
+          "freightAndCharges": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#applicableServiceCharge"
+          },
+          "includedConsignmentItems": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#includedConsignmentItem"
+          },
+          "mainCarriageTransportMovement": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#mainCarriageTransportMovement"
+          },
+          "notifyParty": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#notifyParty"
+          },
+          "onCarriageTransportMovement": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#onCarriageTransportMovement"
+          },
+          "placeOfDelivery": {
+            "@id": "https://schema.org/Place"
+          },
+          "placeOfReceipt": {
+            "@id": "https://schema.org/Place"
+          },
+          "portOfDischarge": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#unloadingLocation"
+          },
+          "portOfLoading": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#transshipmentLocation"
+          },
+          "preCarriageTransportMovement": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#preCarriageTransportMovement"
+          },
+          "shipper": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consignorParty"
+          },
+          "shippersReferences": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Consignment_identifier_freight_forwarder_assigned"
+          },
+          "termsAndConditions": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#termsAndConditionsDescription"
+          },
+          "totalNumberOfPackages": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageQuantity"
+          },
+          "transportEquipmentQuantity": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#transportEquipmentQuantity"
+          }
+        },
+        "@id": "https://w3id.org/traceability#HouseBillOfLading"
+      },
+      "HouseBillOfLadingCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#HouseBillOfLadingCredential"
+      },
+      "IATAAirWaybill": {
+        "@context": {
+          "accountingInformation": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#typeCode"
+          },
+          "agentAccountNumber": {
+            "@id": "https://schema.org/accountId"
+          },
+          "agentIATACode": {
+            "@id": "https://onerecord.iata.org/cargo/Company#iataCargoAgentCode"
+          },
+          "airWaybillNumber": {
+            "@id": "https://schema.org/orderNumber"
+          },
+          "airlineCodeNumber": {
+            "@id": "https://onerecord.iata.org/cargo/Company#airlineCode"
+          },
+          "airportOfDeparture": {
+            "@id": "https://onerecord.iata.org/cargo/Location#code"
+          },
+          "amountOfInsurance": {
+            "@id": "https://schema.org/value"
+          },
+          "carrier": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#carrierParty"
+          },
+          "chargeCodes": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#chargeCategoryCode"
+          },
+          "collectChargeDeclaration": {
+            "@id": "https://w3id.org/traceability#CollectChargeDeclaration"
+          },
+          "collectTotal": {
+            "@id": "https://schema.org/totalPrice"
+          },
+          "conditionsOfContract": {
+            "@id": "https://schema.org/termsOfService"
+          },
+          "consignee": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consigneeParty"
+          },
+          "consigneesAccountNumber": {
+            "@id": "https://schema.org/accountId"
+          },
+          "consignmentRatingDetails": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#includedConsignmentItem"
+          },
+          "currency": {
+            "@id": "https://schema.org/currency"
+          },
+          "declaredValueForCarriage": {
+            "@id": "https://schema.org/value"
+          },
+          "declaredValueForCustoms": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#customsValueSpecifiedAmount"
+          },
+          "destinationAirport": {
+            "@id": "https://onerecord.iata.org/cargo/Company#airlineCode"
+          },
+          "destinationCollectChargeDeclaration": {
+            "@id": "https://w3id.org/traceability#DestinationCollectChargeDeclaration"
+          },
+          "executedAt": {
+            "@id": "https://schema.org/Place"
+          },
+          "executedOn": {
+            "@id": "https://w3id.org/traceability#executionTime"
+          },
+          "handlingInformation": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#handlingInstructions"
+          },
+          "insuranceClauses": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#contractualClause"
+          },
+          "issuingCarrierAgent": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#carrierAgentParty"
+          },
+          "otherCharges": {
+            "@id": "https://schema.org/price"
+          },
+          "otherChargesType": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#chargeCategoryCode"
+          },
+          "prepaidChargeDeclaration": {
+            "@id": "https://w3id.org/traceability#PrepaidChargeDeclaration"
+          },
+          "prepaidTotal": {
+            "@id": "https://schema.org/totalPrice"
+          },
+          "requestedDate": {
+            "@id": "https://w3id.org/traceability#requestDate"
+          },
+          "requestedFlight": {
+            "@id": "https://schema.org/Flight"
+          },
+          "requestedRouting": {
+            "@id": "https://schema.org/Trip"
+          },
+          "serialNumber": {
+            "@id": "https://schema.org/serialNumber"
+          },
+          "shipper": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consignorParty"
+          },
+          "shippersAccountNumber": {
+            "@id": "https://schema.org/accountId"
+          },
+          "shippersCertificationBox": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#Certification"
+          },
+          "specialCustomsInformation": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#Declaration"
+          },
+          "totalCharge": {
+            "@id": "https://schema.org/totalPrice"
+          },
+          "totalGrossWeight": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#grossWeightMeasure"
+          },
+          "totalNumberOfPieces": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageQuantity"
+          },
+          "waybillType": {
+            "@id": "https://schema.org/DigitalDocument"
+          },
+          "weightValuationChargesType": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#chargeCategoryCode"
+          }
+        },
+        "@id": "https://w3id.org/traceability#IATAAirWaybill"
+      },
+      "IATAAirWaybillCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#IATAAirWaybillCredential"
+      },
+      "ImmediateDelivery": {
+        "@context": {
+          "arrivalDate": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#actualArrivalRelatedDateTime"
+          },
+          "assignedIdentifier": {
+            "@id": "https://schema.org/identifier"
+          },
+          "assignedIdentifierType": {
+            "@id": "https://w3id.org/traceability#assignedIdentifierType"
+          },
+          "bolNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Bill_of_lading_number"
+          },
+          "bolType": {
+            "@id": "https://w3id.org/traceability#bolType"
+          },
+          "bondType": {
+            "@id": "https://w3id.org/traceability#bondType"
+          },
+          "bondValue": {
+            "@id": "https://schema.org/MonetaryAmount"
+          },
+          "centralizedExaminationSite": {
+            "@id": "https://w3id.org/traceability#centralizedExaminationSite"
+          },
+          "conveyanceName": {
+            "@id": "https://w3id.org/traceability#conveyanceName"
+          },
+          "conveyanceNameOrFreeTradeZoneID": {
+            "@id": "https://w3id.org/traceability#conveyanceNameOrFreeTradeZoneID"
+          },
+          "entryNumber": {
+            "@id": "https://schema.org/identifier"
+          },
+          "entryType": {
+            "@id": "https://w3id.org/traceability#entryType"
+          },
+          "entryValue": {
+            "@id": "https://schema.org/MonetaryAmount"
+          },
+          "generalOrderNumber": {
+            "@id": "https://w3id.org/traceability#generalOrderNumber"
+          },
+          "headerParties": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#Party"
+          },
+          "importer": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#importerParty"
+          },
+          "inBondNumber": {
+            "@id": "https://w3id.org/traceability#inBondNumber"
+          },
+          "lineItems": {
+            "@id": "https://w3id.org/traceability#lineItems"
+          },
+          "locationOfGoods": {
+            "@id": "https://schema.org/Place"
+          },
+          "nonAMS": {
+            "@id": "https://w3id.org/traceability#nonAMS"
+          },
+          "originatingWarehouseEntryNumber": {
+            "@id": "https://w3id.org/traceability#originatingWarehouseEntryNumber"
+          },
+          "portOfEntry": {
+            "@id": "https://schema.org/Place"
+          },
+          "portOfUnlading": {
+            "@id": "https://schema.org/Place"
+          },
+          "quantity": {
+            "@id": "https://w3id.org/traceability#quantity"
+          },
+          "referenceIDCode": {
+            "@id": "https://w3id.org/traceability#referenceIDCode"
+          },
+          "referenceIDNumber": {
+            "@id": "https://w3id.org/traceability#referenceIDNumber"
+          },
+          "scac": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Standard_Carrier_Alpha_Code_(SCAC)_number"
+          },
+          "splitBill": {
+            "@id": "https://w3id.org/traceability#splitBill"
+          },
+          "suretyCode": {
+            "@id": "https://w3id.org/traceability#suretyCode"
+          },
+          "transportMode": {
+            "@id": "https://w3id.org/traceability#transportMode"
+          },
+          "voyageFlightTrip": {
+            "@id": "https://w3id.org/traceability#voyageFlightTrip"
+          }
+        },
+        "@id": "https://w3id.org/traceability#ImmediateDelivery"
+      },
+      "ImmediateDeliveryEntity": {
+        "@context": {
+          "assignedIdentifier": {
+            "@id": "https://schema.org/identifier"
+          },
+          "assignedIdentifierType": {
+            "@id": "https://w3id.org/traceability#assignedIdentifierType"
+          },
+          "buyer": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#buyerParty"
+          },
+          "consignee": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consigneeParty"
+          },
+          "importer": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#manufacturerParty"
+          },
+          "seller": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#sellerParty"
+          }
+        },
+        "@id": "https://w3id.org/traceability#ImmediateDeliveryEntity"
+      },
+      "ImmediateDeliveryLineItem": {
+        "@context": {
+          "commodity": {
+            "@id": "https://w3id.org/traceability#Commodity"
+          },
+          "countryOfOrigin": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#originCountry"
+          },
+          "freeTradeZoneFilingDate": {
+            "@id": "https://schema.org/Date"
+          },
+          "freeTradeZoneStatus": {
+            "@id": "https://w3id.org/traceability#freeTradeZoneStatus"
+          },
+          "itemCount": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#despatchedQuantity"
+          },
+          "itemParty": {
+            "@id": "https://w3id.org/traceability#itemParty"
+          },
+          "productDescription": {
+            "@id": "https://schema.org/description"
+          },
+          "value": {
+            "@id": "https://schema.org/MonetaryAmount"
+          }
+        },
+        "@id": "https://w3id.org/traceability#ImmediateDeliveryLineItem"
+      },
+      "ImporterSecurityFiling": {
+        "@context": {
+          "buyer": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#buyerParty"
+          },
+          "consignee": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consigneeParty"
+          },
+          "consolidator": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consolidatorParty"
+          },
+          "containerStuffingLocation": {
+            "@id": "https://w3id.org/traceability#containerStuffingLocation"
+          },
+          "filingItems": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#includedConsignmentItem"
+          },
+          "importer": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#importerParty"
+          },
+          "seller": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#sellerParty"
+          },
+          "shipToParty": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#shipToParty"
+          }
+        },
+        "@id": "https://w3id.org/traceability#ImporterSecurityFiling"
+      },
+      "ImporterSecurityFilingCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#ImporterSecurityFilingCredential"
+      },
+      "Inbond": {
+        "@context": {
+          "billOfLadingNumber": {
+            "@id": "https://w3id.org/identifier"
+          },
+          "carrier": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#carrierParty"
+          },
+          "entryId": {
+            "@id": "https://w3id.org/identifier"
+          },
+          "expectedDeliveryDate": {
+            "@id": "https://schema.org/DateTime"
+          },
+          "ftzNo": {
+            "@id": "https://w3id.org/identifier"
+          },
+          "inBondNumber": {
+            "@id": "https://w3id.org/identifier"
+          },
+          "inBondType": {
+            "@id": "https://w3id.org/identifier"
+          },
+          "irsNumber": {
+            "@id": "https://w3id.org/identifier"
+          },
+          "portOfArrival": {
+            "@id": "https://www.gs1.org/voc/Place"
+          },
+          "portOfDestination": {
+            "@id": "https://www.gs1.org/voc/Place"
+          },
+          "portOfEntry": {
+            "@id": "https://www.gs1.org/voc/Place"
+          },
+          "product": {
+            "@id": "https://www.gs1.org/voc/Product"
+          },
+          "recipient": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consigneeParty"
+          },
+          "shipment": {
+            "@id": "https://schema.org/ParcelDelivery"
+          },
+          "totalOrderValue": {
+            "@id": "https://schema.org/PriceSpecification"
+          },
+          "valuePerItem": {
+            "@id": "https://schema.org/PriceSpecification"
+          }
+        },
+        "@id": "https://w3id.org/traceability#Inbond"
+      },
+      "InspectionReport": {
+        "@context": {
+          "comment": {
+            "@id": "https://schema.org/comment"
+          },
+          "inspectors": {
+            "@id": "https://schema.org/Person"
+          },
+          "observation": {
+            "@id": "https://schema.org/ItemList"
+          },
+          "place": {
+            "@id": "https://schema.org/Place"
+          }
+        },
+        "@id": "https://w3id.org/traceability#InspectionReport"
+      },
+      "Inspector": {
+        "@context": {
+          "person": {
+            "@id": "https://schema.org/Person"
+          },
+          "qualification": {
+            "@id": "https://w3id.org/traceability#qualification"
+          }
+        },
+        "@id": "https://w3id.org/traceability#Inspector"
+      },
+      "Instructions": {
+        "@context": {
+          "description": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#description"
+          }
+        },
+        "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#Instructions"
+      },
+      "IntellectualPropertyRights": {
+        "@context": {
+          "intellectualPropertyRightsOwner": {
+            "@id": "https://w3id.org/traceability#intellectualPropertyRightsOwner"
+          },
+          "intellectualPropertyRightsProduct": {
+            "@id": "https://w3id.org/traceability#intellectualPropertyRightsProduct"
+          },
+          "intellectualPropertyRightsType": {
+            "@id": "https://w3id.org/traceability#intellectualPropertyRightsType"
+          }
+        },
+        "@id": "https://w3id.org/traceability#IntellectualPropertyRights"
+      },
+      "IntellectualPropertyRightsAffirmation": {
+        "@context": {
+          "affirmingParty": {
+            "@id": "https://w3id.org/traceability#affirmingParty"
+          },
+          "evidenceDocumentUrl": {
+            "@id": "https://schema.org/url"
+          },
+          "intellectualPropertyRightsType": {
+            "@id": "https://w3id.org/traceability#intellectualPropertyRightsType"
+          }
+        },
+        "@id": "https://w3id.org/traceability#IntellectualPropertyRightsAffirmation"
+      },
+      "IntellectualPropertyRightsCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#IntellectualPropertyRightsCredential"
+      },
+      "IntentToImport": {
+        "@context": {
+          "declarationDate": {
+            "@id": "https://schema.org/startDate"
+          },
+          "exporter": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#exporterParty"
+          },
+          "importer": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#importerParty"
+          },
+          "product": {
+            "@id": "https://www.gs1.org/voc/Product"
+          }
+        },
+        "@id": "https://w3id.org/traceability#IntentToImport"
+      },
+      "IntentToImportCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#IntentToImportCredential"
+      },
+      "InventoryRegistrationCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#InventoryRegistrationCredential"
+      },
+      "Invoice": {
+        "@context": {
+          "billOfLadingNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Bill_of_lading_number"
+          },
+          "buyer": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#buyerParty"
+          },
+          "comments": {
+            "@id": "https://schema.org/Comment"
+          },
+          "customerReferenceNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Customer_reference_number"
+          },
+          "deductions": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#deductionAmount"
+          },
+          "destinationCountry": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#destinationCountry"
+          },
+          "discounts": {
+            "@id": "https://schema.org/discount"
+          },
+          "exporter": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#exporterParty"
+          },
+          "freightCost": {
+            "@id": "https://schema.org/DeliveryChargeSpecification"
+          },
+          "identifier": {
+            "@id": "https://schema.org/identifier"
+          },
+          "importer": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#importerParty"
+          },
+          "insuranceCost": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#insuranceChargeTotalAmount"
+          },
+          "invoiceDate": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#invoiceDateTime"
+          },
+          "invoiceNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#invoiceIssuerReference"
+          },
+          "itemsShipped": {
+            "@id": "https://schema.org/itemShipped"
+          },
+          "letterOfCreditNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#letterOfCreditDocument"
+          },
+          "originCountry": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#originCountry"
+          },
+          "packageQuantity": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageQuantity"
+          },
+          "portOfEntry": {
+            "@id": "https://schema.org/Place"
+          },
+          "provider": {
+            "@id": "https://schema.org/provider"
+          },
+          "purchaseDate": {
+            "@id": "https://schema.org/paymentDueDate"
+          },
+          "referencesOrder": {
+            "@id": "https://schema.org/referencesOrder"
+          },
+          "seller": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#sellerParty"
+          },
+          "shipFromParty": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#shipFromParty"
+          },
+          "shipToParty": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#shipToParty"
+          },
+          "tax": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#taxTotalAmount"
+          },
+          "termsOfDelivery": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#specifiedDeliveryTerms"
+          },
+          "termsOfPayment": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#specifiedPaymentTerms"
+          },
+          "termsOfSettlement": {
+            "@id": "https://schema.org/currency"
+          },
+          "totalPaymentDue": {
+            "@id": "https://schema.org/totalPaymentDue"
+          },
+          "totalWeight": {
+            "@id": "https://schema.org/weight"
+          }
+        },
+        "@id": "https://schema.org/Invoice"
+      },
+      "LEIaddress": {
+        "@context": {
+          "addressNumberWithinBuilding": {
+            "@id": "https://schema.org/value"
+          },
+          "city": {
+            "@id": "https://schema.org/addressLocality"
+          },
+          "country": {
+            "@id": "https://schema.org/addressCountry"
+          },
+          "language": {
+            "@id": "https://schema.org/Language"
+          },
+          "mailRouting": {
+            "@id": "https://schema.org/Trip"
+          },
+          "postalCode": {
+            "@id": "https://schema.org/postalCode"
+          },
+          "region": {
+            "@id": "https://schema.org/addressRegion"
+          }
+        },
+        "@id": "https://w3id.org/traceability#LEIaddress"
+      },
+      "LEIauthority": {
+        "@context": {
+          "otherValidationAuthorityID": {
+            "@id": "https://schema.org/taxID"
+          },
+          "validationAuthorityEntityID": {
+            "@id": "https://schema.org/leiCode"
+          },
+          "validationAuthorityID": {
+            "@id": "https://schema.org/identifier"
+          }
+        },
+        "@id": "https://w3id.org/traceability#LEIauthority"
+      },
+      "LEIentity": {
+        "@context": {
+          "associatedEntity": {
+            "@id": "https://schema.org/Organization"
+          },
+          "entityCategory": {
+            "@id": "https://schema.org/category"
+          },
+          "expirationDate": {
+            "@id": "https://schema.org/expires"
+          },
+          "expirationReason": {
+            "@id": "https://schema.org/Answer"
+          },
+          "headquartersAddress": {
+            "@id": "https://schema.org/PostalAddress"
+          },
+          "legalAddress": {
+            "@id": "https://w3id.org/traceability#LEIaddress"
+          },
+          "legalForm": {
+            "@id": "https://schema.org/additionalType"
+          },
+          "legalJurisdiction": {
+            "@id": "https://schema.org/countryOfOrigin"
+          },
+          "legalName": {
+            "@id": "https://schema.org/legalName"
+          },
+          "legalNameLanguage": {
+            "@id": "https://schema.org/Language"
+          },
+          "otherAddresses": {
+            "@id": "https://schema.org/Place"
+          },
+          "registrationAuthority": {
+            "@id": "https://w3id.org/traceability#LEIauthority"
+          },
+          "status": {
+            "@id": "https://schema.org/status"
+          },
+          "successorEntity": {
+            "@id": "https://schema.org/Corporation"
+          }
+        },
+        "@id": "https://w3id.org/traceability#LEIentity"
+      },
+      "LEIevidenceDocument": {
+        "@context": {
+          "entity": {
+            "@id": "https://w3id.org/traceability#LEIentity"
+          },
+          "lei": {
+            "@id": "https://www.gleif.org/en/about-lei/iso-17442-the-lei-code-structure#"
+          },
+          "registration": {
+            "@id": "https://w3id.org/traceability#LEIregistration"
+          }
+        },
+        "@id": "https://w3id.org/traceability#LEIevidenceDocument"
+      },
+      "LEIregistration": {
+        "@context": {
+          "initialRegistrationDate": {
+            "@id": "https://schema.org/dateIssued"
+          },
+          "lastUpdateDate": {
+            "@id": "https://schema.org/dateModified"
+          },
+          "managingLou": {
+            "@id": "https://www.gleif.org/en/about-lei/iso-17442-the-lei-code-structure#"
+          },
+          "nextRenewalDate": {
+            "@id": "https://schema.org/validThrough"
+          },
+          "status": {
+            "@id": "https://schema.org/status"
+          },
+          "validationAuthority": {
+            "@id": "https://w3id.org/traceability#LEIauthority"
+          },
+          "validationSources": {
+            "@id": "https://schema.org/eventStatus"
+          }
+        },
+        "@id": "https://w3id.org/traceability#LEIregistration"
+      },
+      "LinkRole": {
+        "@context": {
+          "linkRelationship": {
+            "@id": "https://schema.org/linkRelationship"
+          },
+          "target": {
+            "@id": "https://schema.org/target"
+          }
+        },
+        "@id": "https://schema.org/LinkRole"
+      },
+      "MapResource": {
+        "@context": {
+          "external": {
+            "@id": "https://w3id.org/traceability#ExternalResource"
+          },
+          "geoJson": {
+            "@id": "https://schema.org/geo"
+          },
+          "resourceType": {
+            "@id": "https://schema.org/additionalType"
+          }
+        },
+        "@id": "https://w3id.org/traceability#MapResource"
+      },
+      "MasterBillOfLading": {
+        "@context": {
+          "billOfLadingNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Bill_of_lading_number"
+          },
+          "bookingNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#carrierAssignedId"
+          },
+          "carrier": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#carrierParty"
+          },
+          "consignee": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consigneeParty"
+          },
+          "declaredValue": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#declaredValueForCarriageAmount"
+          },
+          "freightAndCharges": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#applicableServiceCharge"
+          },
+          "includedConsignmentItems": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#includedConsignmentItem"
+          },
+          "mainCarriageTransportMovement": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#mainCarriageTransportMovement"
+          },
+          "notifyParty": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#notifyParty"
+          },
+          "onCarriageTransportMovement": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#onCarriageTransportMovement"
+          },
+          "placeOfDelivery": {
+            "@id": "https://schema.org/Place"
+          },
+          "placeOfReceipt": {
+            "@id": "https://schema.org/Place"
+          },
+          "portOfDischarge": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#unloadingLocation"
+          },
+          "portOfLoading": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#transshipmentLocation"
+          },
+          "preCarriageTransportMovement": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#preCarriageTransportMovement"
+          },
+          "shippedOnBoardDate": {
+            "@id": "https://schema.org/Date"
+          },
+          "shipper": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consignorParty"
+          },
+          "shippersReferences": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Consignment_identifier_freight_forwarder_assigned"
+          },
+          "termsAndConditions": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#termsAndConditionsDescription"
+          },
+          "totalNumberOfPackages": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageQuantity"
+          },
+          "transportEquipmentQuantity": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#transportEquipmentQuantity"
+          },
+          "utilizedTransportEquipment": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#utilizedTransportEquipment"
+          }
+        },
+        "@id": "https://w3id.org/traceability#MasterBillOfLading"
+      },
+      "MasterBillOfLadingCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#MasterBillOfLadingCredential"
+      },
+      "MeasuredProperty": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#MeasuredProperty"
+      },
+      "MeasuredValue": {
+        "@context": {
+          "unitCode": {
+            "@id": "https://schema.org/unitCode"
+          },
+          "value": {
+            "@id": "https://www.schema.org/value"
+          }
+        },
+        "@id": "https://www.schema.org/QuantitativeValue"
+      },
+      "MechanicalProperty": {
+        "@context": {
+          "description": {
+            "@id": "https://schema.org/description"
+          },
+          "identifier": {
+            "@id": "https://schema.org/identifier"
+          },
+          "name": {
+            "@id": "https://schema.org/name"
+          }
+        },
+        "@id": "https://w3id.org/traceability#MechanicalProperty"
+      },
+      "MillTestReportCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#MillTestReportCredential"
+      },
+      "MultiModalBillOfLading": {
+        "@context": {
+          "billOfLadingNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Bill_of_lading_number"
+          },
+          "bookingNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#carrierAssignedId"
+          },
+          "carrier": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#carrierParty"
+          },
+          "consignee": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consigneeParty"
+          },
+          "declaredValue": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#declaredValueForCarriageAmount"
+          },
+          "freightAndCharges": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#applicableServiceCharge"
+          },
+          "includedConsignmentItems": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#includedConsignmentItem"
+          },
+          "mainCarriageTransportMovement": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#mainCarriageTransportMovement"
+          },
+          "notifyParty": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#notifyParty"
+          },
+          "onCarriageTransportMovement": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#onCarriageTransportMovement"
+          },
+          "placeOfDelivery": {
+            "@id": "https://schema.org/Place"
+          },
+          "placeOfReceipt": {
+            "@id": "https://schema.org/Place"
+          },
+          "portOfDischarge": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#unloadingLocation"
+          },
+          "portOfLoading": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#transshipmentLocation"
+          },
+          "preCarriageTransportMovement": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#preCarriageTransportMovement"
+          },
+          "shippedOnBoardDate": {
+            "@id": "https://schema.org/Date"
+          },
+          "shipper": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consignorParty"
+          },
+          "shippersReferences": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Consignment_identifier_freight_forwarder_assigned"
+          },
+          "termsAndConditions": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#termsAndConditionsDescription"
+          },
+          "totalNumberOfPackages": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageQuantity"
+          },
+          "transportEquipmentQuantity": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#transportEquipmentQuantity"
+          },
+          "utilizedTransportEquipment": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#utilizedTransportEquipment"
+          }
+        },
+        "@id": "https://w3id.org/traceability#MultiModalBillOfLading"
+      },
+      "MultiModalBillOfLadingCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#MultiModalBillOfLadingCredential"
+      },
+      "NAISMADateTime": {
+        "@context": {
+          "collectionDate": {
+            "@id": "http://rs.tdwg.org/dwc/terms/eventDate"
+          },
+          "dateAccuracyDays": {
+            "@id": "https://schema.org/value"
+          }
+        },
+        "@id": "https://w3id.org/traceability#NAISMADateTime"
+      },
+      "NAISMAInfestation": {
+        "@context": {
+          "areaSurveyed": {
+            "@id": "http://rs.tdwg.org/dwc/terms/measurementValue"
+          },
+          "incidence": {
+            "@id": "http://rs.tdwg.org/dwc/terms/measurementValue"
+          },
+          "infestedArea": {
+            "@id": "http://rs.tdwg.org/dwc/terms/measurementValue"
+          },
+          "organismQuantity": {
+            "@id": "http://rs.tdwg.org/dwc/terms/organismQuantity"
+          },
+          "organismQuantityUnits": {
+            "@id": "https://schema.org/unitText"
+          },
+          "severity": {
+            "@id": "http://rs.tdwg.org/dwc/terms/measurementValue"
+          },
+          "severityUnits": {
+            "@id": "https://schema.org/unitText"
+          }
+        },
+        "@id": "https://w3id.org/traceability#NAISMAInfestation"
+      },
+      "NAISMAInformationSource": {
+        "@context": {
+          "dataSource": {
+            "@id": "https://w3id.org/traceability#Entity"
+          },
+          "examiner": {
+            "@id": "http://rs.tdwg.org/dwc/terms/recordedBy"
+          },
+          "reference": {
+            "@id": "http://rs.tdwg.org/dwc/terms/associatedReferences"
+          }
+        },
+        "@id": "https://w3id.org/traceability#NAISMAInformationSource"
+      },
+      "NAISMALocation": {
+        "@context": {
+          "centroidType": {
+            "@id": "https://schema.org/polygon"
+          },
+          "coordinateUncertainty": {
+            "@id": "http://rs.tdwg.org/dwc/terms/coordinateUncertaintyInMeters"
+          },
+          "dataType": {
+            "@id": "https://schema.org/additionalType"
+          },
+          "datum": {
+            "@id": "http://rs.tdwg.org/dwc/terms/geodeticDatum"
+          },
+          "description": {
+            "@id": "https://schema.org/description"
+          },
+          "ecosystem": {
+            "@id": "http://rs.tdwg.org/dwc/terms/locationRemarks"
+          },
+          "location": {
+            "@id": "https://w3id.org/traceability#Place"
+          },
+          "sourceOfLocation": {
+            "@id": "http://rs.tdwg.org/dwc/terms/georeferenceProtocol"
+          },
+          "wellKnownText": {
+            "@id": "http://rs.tdwg.org/dwc/terms/footprintWKT"
+          }
+        },
+        "@id": "https://w3id.org/traceability#NAISMALocation"
+      },
+      "NAISMARecordLevelIdentifiers": {
+        "@context": {
+          "catalogNumber": {
+            "@id": "https://schema.org/identifier"
+          },
+          "pid": {
+            "@id": "https://schema.org/identifier"
+          },
+          "uuid": {
+            "@id": "https://schema.org/identifier"
+          }
+        },
+        "@id": "https://w3id.org/traceability#NAISMARecordLevelIdentifiers"
+      },
+      "NAISMARecordStatus": {
+        "@context": {
+          "managementStatus": {
+            "@id": "https://schema.org/status"
+          },
+          "method": {
+            "@id": "http://rs.tdwg.org/dwc/terms/measurementMethod"
+          },
+          "occurrenceStatus": {
+            "@id": "https://schema.org/status"
+          },
+          "populationStatus": {
+            "@id": "http://rs.tdwg.org/dwc/terms/degreeOfEstablishment"
+          },
+          "recordBasis": {
+            "@id": "http://rs.tdwg.org/dwc/terms/samplingProtocol"
+          },
+          "recordType": {
+            "@id": "https://schema.org/description"
+          },
+          "verificationMethod": {
+            "@id": "http://rs.tdwg.org/dwc/terms/identificationRemarks"
+          }
+        },
+        "@id": "https://w3id.org/traceability#NAISMARecordStatus"
+      },
+      "NAISMASubject": {
+        "@context": {
+          "comments": {
+            "@id": "http://rs.tdwg.org/dwc/terms/occurrenceRemarks"
+          },
+          "hostSpecies": {
+            "@id": "https://w3id.org/traceability#Taxonomy"
+          },
+          "lifeStage": {
+            "@id": "http://rs.tdwg.org/dwc/terms/lifeStage"
+          },
+          "sex": {
+            "@id": "http://rs.tdwg.org/dwc/terms/sex"
+          }
+        },
+        "@id": "https://w3id.org/traceability#NAISMASubject"
+      },
+      "NAISMATaxonomy": {
+        "@context": {
+          "commonName": {
+            "@id": "http://rs.tdwg.org/dwc/terms/vernacularName"
+          },
+          "speciesName": {
+            "@id": "https://w3id.org/traceability#Taxonomy"
+          },
+          "taxonomicSerialNumber": {
+            "@id": "http://rs.tdwg.org/dwc/terms/taxonID"
+          }
+        },
+        "@id": "https://w3id.org/traceability#NAISMATaxonomy"
+      },
+      "NaturalGasProduct": {
+        "@context": {
+          "HSCode": {
+            "@id": "https://w3id.org/identifier"
+          },
+          "UWI": {
+            "@id": "https://schema.org/identifier"
+          },
+          "facility": {
+            "@id": "https://www.gs1.org/voc/Place"
+          },
+          "observation": {
+            "@id": "https://w3id.org/traceability#observation"
+          },
+          "product": {
+            "@id": "https://www.gs1.org/voc/Product"
+          },
+          "productionDate": {
+            "@id": "https://schema.org/DateTime"
+          }
+        },
+        "@id": "https://w3id.org/traceability#NaturalGasProduct"
+      },
+      "NaturalGasProductCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#NaturalGasProductCredential"
+      },
+      "OGBillOfLading": {
+        "@context": {
+          "arrivalDate": {
+            "@id": "https://schema.org/DateTime"
+          },
+          "batchNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#batchIdentificationId"
+          },
+          "billOfLading": {
+            "@id": "https://w3id.org/traceability#BillOfLading"
+          },
+          "closingVolume": {
+            "@id": "https://schema.org/MeasuredValue"
+          },
+          "freightChargeTerms": {
+            "@id": "https://www.schema.org/value"
+          },
+          "observation": {
+            "@id": "https://w3id.org/traceability#observation"
+          },
+          "openingVolume": {
+            "@id": "https://schema.org/MeasuredValue"
+          },
+          "shippingDate": {
+            "@id": "https://schema.org/DateTime"
+          },
+          "totalOrderValue": {
+            "@id": "https://www.schema.org/value"
+          },
+          "valuePerItem": {
+            "@id": "https://www.schema.org/value"
+          }
+        },
+        "@id": "https://w3id.org/traceability#OGBillOfLading"
+      },
+      "Observation": {
+        "@context": {
+          "date": {
+            "@id": "https://schema.org/observationDate"
+          },
+          "measurement": {
+            "@id": "https://w3id.org/traceability#MeasuredValue"
+          },
+          "property": {
+            "@id": "https://schema.org/measuredProperty"
+          }
+        },
+        "@id": "https://schema.org/Observation"
+      },
+      "Order": {
+        "@context": {
+          "orderNumber": {
+            "@id": "https://schema.org/orderNumber"
+          },
+          "orderedItems": {
+            "@id": "https://schema.org/orderedItem"
+          }
+        },
+        "@id": "https://schema.org/Order"
+      },
+      "OrderConfirmationCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#OrderConfirmationCredential"
+      },
+      "OrderItem": {
+        "@context": {
+          "fulfillmentCenter": {
+            "@id": "https://vocabulary.uncefact.org/logisticsServiceProviderParty"
+          },
+          "marketplace": {
+            "@id": "https://vocabulary.uncefact.org/Marketplace"
+          },
+          "orderedItem": {
+            "@id": "https://schema.org/orderedItem"
+          },
+          "orderedQuantity": {
+            "@id": "https://schema.org/orderQuantity"
+          }
+        },
+        "@id": "https://schema.org/OrderItem"
+      },
+      "OrganicCertificate": {
+        "@context": {
+          "anniversaryDate": {
+            "@id": "https://www.gs1.org/voc/certificationEndDate"
+          },
+          "certifiedOperation": {
+            "@id": "https://www.gs1.org/voc/certificationSubject"
+          },
+          "certifyingAgent": {
+            "@id": "https://www.gs1.org/voc/certificationAgency"
+          },
+          "countryOfIssuance": {
+            "@id": "https://www.gs1.org/voc/countryCode"
+          },
+          "effectiveDate": {
+            "@id": "https://www.gs1.org/voc/certificationStartDate"
+          },
+          "issueDate": {
+            "@id": "https://www.gs1.org/voc/initialCertificationDate"
+          },
+          "operationCategory": {
+            "@id": "https://www.gs1.org/voc/certificationStatement"
+          },
+          "organicProducts": {
+            "@id": "https://www.gs1.org/voc/certificationStatement"
+          }
+        },
+        "@id": "https://w3id.org/traceability#OrganicCertificate"
+      },
+      "OrganicCertificateCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#OrganicCertificateCredential"
+      },
+      "OrganicInspection": {
+        "@context": {
+          "OSPSectionReviews": {
+            "@id": "https://w3id.org/traceability#OrganicOSPSectionReview"
+          },
+          "announcedInspection": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#information"
+          },
+          "applicantCertificationNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#identificationId"
+          },
+          "attachments": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#additionalDocument"
+          },
+          "authorizedOperationContacts": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#specifiedPerson"
+          },
+          "commonInfo": {
+            "@id": "https://w3id.org/traceability#AgricultureInspectionCommonInfo"
+          },
+          "continuingCertification": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#information"
+          },
+          "estimatedHarvestDate": {
+            "@id": "https://www.gs1.org/voc/harvestDate"
+          },
+          "introductionOperationDescription": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#description"
+          },
+          "issuesRequests": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#additionalDescription"
+          },
+          "newApplicant": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#information"
+          },
+          "newLocationActivity": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#information"
+          },
+          "peoplePresent": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#associatedParty"
+          },
+          "pesticideResidueSampling": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#information"
+          },
+          "reinstatement": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#information"
+          },
+          "resolutionIssuesActionItems": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#description"
+          },
+          "samplingDetails": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#content"
+          }
+        },
+        "@id": "https://w3id.org/traceability#OrganicInspection"
+      },
+      "OrganicOSPSectionReview": {
+        "@context": {
+          "OSPSectionCode": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#standard"
+          },
+          "attachments": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#additionalDocument"
+          },
+          "resultCode": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#assertionCode"
+          },
+          "verificationExplanations": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#remarks"
+          }
+        },
+        "@id": "https://w3id.org/traceability#OrganicOSPSectionReview"
+      },
+      "OrganicProductCertification": {
+        "@context": {
+          "agricultureProduct": {
+            "@id": "https://www.gs1.org/voc/certificationSubject"
+          },
+          "isCertified": {
+            "@id": "https://www.gs1.org/voc/certificationStatus"
+          },
+          "organicCertificate": {
+            "@id": "https://www.gs1.org/voc/certification"
+          }
+        },
+        "@id": "https://w3id.org/traceability#OrganicProductCertification"
+      },
+      "OrganicReview": {
+        "@context": {
+          "additionalInformation": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#content"
+          },
+          "certificationDecision": {
+            "@id": "https://www.gs1.org/voc/certificationStatus"
+          },
+          "decisionMaker": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#specifiedPerson"
+          },
+          "inspectionReport": {
+            "@id": "https://w3id.org/traceability#OrganicInspection"
+          },
+          "reviewer": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#specifiedPerson"
+          }
+        },
+        "@id": "https://w3id.org/traceability#OrganicReview"
+      },
+      "Organization": {
+        "@context": {
+          "brand": {
+            "@id": "https://schema.org/Brand"
+          },
+          "contactPoint": {
+            "@id": "https://schema.org/ContactPoint"
+          },
+          "description": {
+            "@id": "https://schema.org/description"
+          },
+          "email": {
+            "@id": "https://schema.org/email"
+          },
+          "faxNumber": {
+            "@id": "https://schema.org/faxNumber"
+          },
+          "globalLocationNumber": {
+            "@id": "https://schema.org/globalLocationNumber"
+          },
+          "iataCarrierCode": {
+            "@id": "https://onerecord.iata.org/cargo/Company#airlineCode"
+          },
+          "legalName": {
+            "@id": "https://schema.org/legalName"
+          },
+          "leiCode": {
+            "@id": "https://schema.org/leiCode"
+          },
+          "location": {
+            "@id": "https://schema.org/location"
+          },
+          "name": {
+            "@id": "https://schema.org/name"
+          },
+          "phoneNumber": {
+            "@id": "https://schema.org/telephone"
+          },
+          "taxId": {
+            "@id": "https://schema.org/taxID"
+          },
+          "url": {
+            "@id": "https://schema.org/url"
+          }
+        },
+        "@id": "https://schema.org/Organization"
+      },
+      "OssfScorecard": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#OssfScorecard"
+      },
+      "PGAShipmentStatus": {
+        "@context": {
+          "entryLineSequence": {
+            "@id": "https://w3id.org/traceability#entryLineSequence"
+          },
+          "entryNo": {
+            "@id": "https://w3id.org/traceability#entryNo"
+          },
+          "recordNo": {
+            "@id": "https://w3id.org/traceability#recordNo"
+          },
+          "statusCode": {
+            "@id": "https://w3id.org/traceability#statusCode"
+          },
+          "statusCodeDescription": {
+            "@id": "https://w3id.org/traceability#statusCodeDescription"
+          },
+          "subReasonCode": {
+            "@id": "https://w3id.org/traceability#subReasonCode"
+          },
+          "subReasonCodeDescription": {
+            "@id": "https://w3id.org/traceability#subReasonCodeDescription"
+          },
+          "validCodeReason": {
+            "@id": "https://w3id.org/traceability#validCodeReason"
+          },
+          "validCodeReasonDescription": {
+            "@id": "https://w3id.org/traceability#validCodeReasonDescription"
+          }
+        },
+        "@id": "https://w3id.org/traceability#PGAShipmentStatus"
+      },
+      "PGAShipmentStatusCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#PGAShipmentStatusCredential"
+      },
+      "PGAShipmentStatusList": {
+        "@context": {
+          "pgaShipmentStatusItems": {
+            "@id": "https://schema.org/ItemList"
+          }
+        },
+        "@id": "https://w3id.org/traceability#PGAShipmentStatusList"
+      },
+      "Package": {
+        "@context": {
+          "depth": {
+            "@id": "https://schema.org/depth"
+          },
+          "grossVolume": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#grossVolumeMeasure"
+          },
+          "grossWeight": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#grossWeightMeasure"
+          },
+          "height": {
+            "@id": "https://schema.org/height"
+          },
+          "includedTradeLineItems": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#includedTradeLineItem"
+          },
+          "netWeight": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#netWeightMeasure"
+          },
+          "packagingType": {
+            "@id": "https://www.gs1.org/voc/packagingMaterial"
+          },
+          "perPackageUnitQuantity": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#perPackageUnitQuantity"
+          },
+          "physicalShippingMarks": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#physicalShippingMarks"
+          },
+          "width": {
+            "@id": "https://schema.org/width"
+          }
+        },
+        "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#Package"
+      },
+      "PackingList": {
+        "@context": {
+          "buyer": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#buyerParty"
+          },
+          "deliveryStatus": {
+            "@id": "https://schema.org/deliveryStatus"
+          },
+          "estimatedTimeOfArrival": {
+            "@id": "https://schema.org/arrivalTime"
+          },
+          "handlingInstructions": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#handlingInstructions"
+          },
+          "hasDeliveryMethod": {
+            "@id": "https://schema.org/hasDeliveryMethod"
+          },
+          "invoiceId": {
+            "@id": "https://schema.org/identifier"
+          },
+          "orderNumber": {
+            "@id": "https://schema.org/orderNumber"
+          },
+          "partOfOrder": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#includedConsignmentItem"
+          },
+          "seller": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#sellerParty"
+          },
+          "shipFromParty": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#shipFromParty"
+          },
+          "shipToParty": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#shipToParty"
+          },
+          "shipmentId": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#shipmentIdentificationId"
+          },
+          "totalGrossVolume": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#grossVolumeMeasure"
+          },
+          "totalGrossWeight": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#grossWeightMeasure"
+          },
+          "totalItemQuantity": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#tradeLineItemQuantity"
+          },
+          "totalNetWeight": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#netWeightMeasure"
+          },
+          "totalNumberOfPackages": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageQuantity"
+          },
+          "trackingNumber": {
+            "@id": "https://schema.org/trackingNumber"
+          }
+        },
+        "@id": "https://w3id.org/traceability#PackingList"
+      },
+      "PackingListCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#PackingListCredential"
+      },
+      "ParcelDelivery": {
+        "@context": {
+          "consignee": {
+            "@id": "https://schema.org/Organization"
+          },
+          "deliveryAddress": {
+            "@id": "https://schema.org/deliveryAddress"
+          },
+          "deliveryMethod": {
+            "@id": "https://schema.org/DeliveryMethod"
+          },
+          "expectedArrival": {
+            "@id": "https://schema.org/expectedArrivalFrom"
+          },
+          "item": {
+            "@id": "https://schema.org/itemShipped"
+          },
+          "originAddress": {
+            "@id": "https://schema.org/originAddress"
+          },
+          "partOfOrder": {
+            "@id": "https://schema.org/partOfOrder"
+          },
+          "specialInstructions": {
+            "@id": "https://schema.org/comment"
+          },
+          "trackingNumber": {
+            "@id": "https://schema.org/trackingNumber"
+          }
+        },
+        "@id": "https://schema.org/ParcelDelivery"
+      },
+      "PartOfOrder": {
+        "@context": {
+          "grossVolume": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#grossVolumeMeasure"
+          },
+          "grossWeight": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#grossWeightMeasure"
+          },
+          "itemQuantity": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#tradeLineItemQuantity"
+          },
+          "manufacturer": {
+            "@id": "https://schema.org/Organization"
+          },
+          "netWeight": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#netWeightMeasure"
+          },
+          "orderNumber": {
+            "@id": "https://schema.org/orderNumber"
+          },
+          "packageQuantity": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageQuantity"
+          },
+          "transportPackages": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#Package"
+          }
+        },
+        "@id": "https://schema.org/OrderItem"
+      },
+      "Person": {
+        "@context": {
+          "email": {
+            "@id": "https://schema.org/email"
+          },
+          "firstName": {
+            "@id": "https://schema.org/givenName"
+          },
+          "jobTitle": {
+            "@id": "https://schema.org/jobTitle"
+          },
+          "lastName": {
+            "@id": "https://schema.org/familyName"
+          },
+          "phoneNumber": {
+            "@id": "https://schema.org/telephone"
+          },
+          "taxId": {
+            "@id": "https://schema.org/taxID"
+          },
+          "worksFor": {
+            "@id": "https://schema.org/worksFor"
+          }
+        },
+        "@id": "https://schema.org/Person"
+      },
+      "PestDetermination": {
+        "@context": {
+          "date": {
+            "@id": "https://dwc.tdwg.org/list/#dwc_dateIdentified"
+          },
+          "determination": {
+            "@id": "https://w3id.org/traceability#Taxonomy"
+          },
+          "determinedBy": {
+            "@id": "https://dwc.tdwg.org/list/#dwc_identifiedBy"
+          },
+          "final": {
+            "@id": "https://dwc.tdwg.org/list/#dwc_identificationVerificationStatus"
+          },
+          "method": {
+            "@id": "https://dwc.tdwg.org/list/#dwc_measurementMethod"
+          },
+          "notes": {
+            "@id": "https://dwc.tdwg.org/list/#dwc_identificationRemarks"
+          },
+          "reportable": {
+            "@id": "https://dwc.tdwg.org/list/#dwc_occurrenceStatus"
+          }
+        },
+        "@id": "https://w3id.org/traceability#PestDetermination"
+      },
+      "PestSample": {
+        "@context": {
+          "affected": {
+            "@id": "https://dwc.tdwg.org/list/#dwc_measurementValue"
+          },
+          "aliveAdults": {
+            "@id": "http://rs.tdwg.org/dwc/terms/individualCount"
+          },
+          "aliveCysts": {
+            "@id": "http://rs.tdwg.org/dwc/terms/individualCount"
+          },
+          "aliveEggs": {
+            "@id": "http://rs.tdwg.org/dwc/terms/individualCount"
+          },
+          "aliveJuveniles": {
+            "@id": "http://rs.tdwg.org/dwc/terms/individualCount"
+          },
+          "aliveLarvae": {
+            "@id": "http://rs.tdwg.org/dwc/terms/individualCount"
+          },
+          "aliveNymphs": {
+            "@id": "http://rs.tdwg.org/dwc/terms/individualCount"
+          },
+          "alivePupae": {
+            "@id": "http://rs.tdwg.org/dwc/terms/individualCount"
+          },
+          "castSkins": {
+            "@id": "http://rs.tdwg.org/dwc/terms/individualCount"
+          },
+          "deadAdults": {
+            "@id": "http://rs.tdwg.org/dwc/terms/individualCount"
+          },
+          "deadCysts": {
+            "@id": "http://rs.tdwg.org/dwc/terms/individualCount"
+          },
+          "deadEggs": {
+            "@id": "http://rs.tdwg.org/dwc/terms/individualCount"
+          },
+          "deadJuveniles": {
+            "@id": "http://rs.tdwg.org/dwc/terms/individualCount"
+          },
+          "deadLarvae": {
+            "@id": "http://rs.tdwg.org/dwc/terms/individualCount"
+          },
+          "deadNymphs": {
+            "@id": "http://rs.tdwg.org/dwc/terms/individualCount"
+          },
+          "deadPupae": {
+            "@id": "http://rs.tdwg.org/dwc/terms/individualCount"
+          },
+          "hostName": {
+            "@id": "https://w3id.org/traceability#Taxonomy"
+          },
+          "hostQuantity": {
+            "@id": "http://rs.tdwg.org/dwc/terms/organismQuantity"
+          },
+          "pestDistribution": {
+            "@id": "http://rs.tdwg.org/dwc/terms/degreeOfEstablishment"
+          },
+          "pestProximity": {
+            "@id": "http://rs.tdwg.org/dwc/terms/occurrenceRemarks"
+          },
+          "pestType": {
+            "@id": "http://rs.tdwg.org/dwc/terms/occurrenceRemarks"
+          },
+          "plantDistribution": {
+            "@id": "http://rs.tdwg.org/dwc/terms/degreeOfEstablishment"
+          },
+          "plantPartsAffected": {
+            "@id": "http://rs.tdwg.org/dwc/terms/occurrenceRemarks"
+          },
+          "samplingMethod": {
+            "@id": "http://rs.tdwg.org/dwc/terms/samplingProtocol"
+          },
+          "trapLureType": {
+            "@id": "http://rs.tdwg.org/dwc/terms/samplingProtocol"
+          },
+          "trapNumber": {
+            "@id": "http://rs.tdwg.org/dwc/terms/samplingProtocol"
+          }
+        },
+        "@id": "https://w3id.org/traceability#PestSample"
+      },
+      "Phytosanitary": {
+        "@context": {
+          "additionalDeclaration": {
+            "@id": "https://schema.org/Comment"
+          },
+          "agriculturePackage": {
+            "@id": "https://w3id.org/traceability#AgriculturePackage"
+          },
+          "applicant": {
+            "@id": "https://w3c-ccg.github.io/traceability-vocab/#dfn-entities"
+          },
+          "certificateNumber": {
+            "@id": "https://schema.org/identifier"
+          },
+          "disinfectionChemical": {
+            "@id": "https://schema.org/activeIngredient"
+          },
+          "disinfectionConcentration": {
+            "@id": "https://w3id.org/traceability#disinfectionConcentration"
+          },
+          "disinfectionDate": {
+            "@id": "https://schema.org/validFrom"
+          },
+          "disinfectionDuration": {
+            "@id": "https://schema.org/duration"
+          },
+          "disinfectionTemperature": {
+            "@id": "https://schema.org/MeasuredValue"
+          },
+          "disinfectionTreatment": {
+            "@id": "https://w3id.org/traceability#disinfectionTreatment"
+          },
+          "distinguishingMarks": {
+            "@id": "https://www.gs1.org/voc/variantDescription"
+          },
+          "facility": {
+            "@id": "https://www.gs1.org/voc/Place"
+          },
+          "inspectionDate": {
+            "@id": "https://schema.org/DateTime"
+          },
+          "inspectionType": {
+            "@id": "https://www.schema.org/value"
+          },
+          "inspector": {
+            "@id": "https://w3id.org/traceability#Inspector"
+          },
+          "notes": {
+            "@id": "https://schema.org/Comment"
+          },
+          "observation": {
+            "@id": "https://schema.org/ItemList"
+          },
+          "plantOrg": {
+            "@id": "https://www.gs1.org/voc/Organization"
+          },
+          "portOfEntry": {
+            "@id": "https://w3id.org/traceability#portOfEntry"
+          },
+          "shipment": {
+            "@id": "https://schema.org/AgricultureParcelDelivery"
+          },
+          "signatureDate": {
+            "@id": "https://schema.org/DateTime"
+          }
+        },
+        "@id": "https://w3id.org/traceability/Phytosanitary"
+      },
+      "Place": {
+        "@context": {
+          "address": {
+            "@id": "https://schema.org/PostalAddress"
+          },
+          "geo": {
+            "@id": "https://schema.org/GeoCoordinates"
+          },
+          "globalLocationNumber": {
+            "@id": "https://schema.org/globalLocationNumber"
+          },
+          "iataAirportCode": {
+            "@id": "https://onerecord.iata.org/cargo/Location#code"
+          },
+          "locationName": {
+            "@id": "https://schema.org/name"
+          },
+          "unLocode": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#UNECELOCODE"
+          }
+        },
+        "@id": "https://schema.org/Place"
+      },
+      "PlantSystemsInspection": {
+        "@context": {
+          "additionalViolations": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#description"
+          },
+          "commonInfo": {
+            "@id": "https://w3id.org/traceability#AgricultureInspectionCommonInfo"
+          },
+          "observationsImprovements": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#description"
+          },
+          "productsPacked": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#specifiedProduct"
+          },
+          "questions": {
+            "@id": "https://w3id.org/traceability#PlantSystemsQuestion"
+          },
+          "summaryOfDeficiencies": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#description"
+          }
+        },
+        "@id": "https://w3id.org/traceability#PlantSystemsInspection"
+      },
+      "PlantSystemsInspectionCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#PlantSystemsInspectionCredential"
+      },
+      "PlantSystemsQuestion": {
+        "@context": {
+          "code": {
+            "@id": "https://schema.org/identifier"
+          },
+          "pointsDeducted": {
+            "@id": "https://schema.org/ratingValue"
+          },
+          "pointsWorth": {
+            "@id": "https://schema.org/ratingValue"
+          }
+        },
+        "@id": "https://w3id.org/traceability#PlantSystemsQuestion"
+      },
+      "PostalAddress": {
+        "@context": {
+          "addressCountry": {
+            "@id": "https://schema.org/addressCountry"
+          },
+          "addressLocality": {
+            "@id": "https://schema.org/addressLocality"
+          },
+          "addressRegion": {
+            "@id": "https://schema.org/addressRegion"
+          },
+          "countyCode": {
+            "@id": "https://gs1.org/voc/countyCode"
+          },
+          "crossStreet": {
+            "@id": "https://gs1.org/voc/crossStreet"
+          },
+          "name": {
+            "@id": "https://schema.org/name"
+          },
+          "postOfficeBoxNumber": {
+            "@id": "https://schema.org/postOfficeBoxNumber"
+          },
+          "postalCode": {
+            "@id": "https://schema.org/postalCode"
+          },
+          "streetAddress": {
+            "@id": "https://schema.org/streetAddress"
+          }
+        },
+        "@id": "https://schema.org/PostalAddress"
+      },
+      "PostmanCollection": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#PostmanCollection"
+      },
+      "PriceSpecification": {
+        "@context": {
+          "price": {
+            "@id": "https://schema.org/price"
+          },
+          "priceCurrency": {
+            "@id": "https://schema.org/priceCurrency"
+          }
+        },
+        "@id": "https://schema.org/PriceSpecification"
+      },
+      "Product": {
+        "@context": {
+          "batchNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#batchIdentificationId"
+          },
+          "category": {
+            "@id": "https://schema.org/category"
+          },
+          "commodity": {
+            "@id": "https://w3id.org/traceability#Commodity"
+          },
+          "depth": {
+            "@id": "https://schema.org/depth"
+          },
+          "description": {
+            "@id": "https://schema.org/description"
+          },
+          "gtin": {
+            "@id": "https://schema.org/gtin"
+          },
+          "height": {
+            "@id": "https://schema.org/height"
+          },
+          "images": {
+            "@id": "https://schema.org/image"
+          },
+          "manufacturer": {
+            "@id": "https://schema.org/manufacturer"
+          },
+          "name": {
+            "@id": "https://schema.org/name"
+          },
+          "productPrice": {
+            "@id": "https://schema.org/priceSpecification"
+          },
+          "seller": {
+            "@id": "https://vocabulary.uncefact.org/sellerParty"
+          },
+          "sizeOrAmount": {
+            "@id": "https://schema.org/size"
+          },
+          "sku": {
+            "@id": "https://schema.org/sku"
+          },
+          "weight": {
+            "@id": "https://schema.org/weight"
+          },
+          "width": {
+            "@id": "https://schema.org/width"
+          }
+        },
+        "@id": "https://schema.org/Product"
+      },
+      "ProductRegistrationCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#ProductRegistrationCredential"
+      },
+      "ProformaInvoiceCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#ProformaInvoiceCredential"
+      },
+      "Purchase": {
+        "@context": {
+          "customer": {
+            "@id": "https://w3id.org/traceability#Entity"
+          },
+          "invoice": {
+            "@id": "https://w3id.org/traceability#Invoice"
+          },
+          "purchaseOrderNo": {
+            "@id": "https://schema.org/identifier"
+          }
+        },
+        "@id": "https://w3id.org/traceability#Purchase"
+      },
+      "PurchaseOrder": {
+        "@context": {
+          "buyer": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#buyerParty"
+          },
+          "comments": {
+            "@id": "https://schema.org/Comment"
+          },
+          "currencyOfSettlement": {
+            "@id": "https://schema.org/currency"
+          },
+          "destinationCountry": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#destinationCountry"
+          },
+          "discounts": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#deductionAmount"
+          },
+          "exporter": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#exporterParty"
+          },
+          "freightCost": {
+            "@id": "https://schema.org/DeliveryChargeSpecification"
+          },
+          "importer": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#importerParty"
+          },
+          "insuranceCost": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#insuranceChargeTotalAmount"
+          },
+          "itemsOrdered": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#TradeLineItem"
+          },
+          "orderDate": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#buyerOrderDateTime"
+          },
+          "originCountry": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#originCountry"
+          },
+          "packageQuantity": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageQuantity"
+          },
+          "portOfEntry": {
+            "@id": "https://schema.org/Place"
+          },
+          "provider": {
+            "@id": "https://schema.org/provider"
+          },
+          "purchaseOrderNo": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Proposed_purchase_order_reference_number"
+          },
+          "seller": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#sellerParty"
+          },
+          "shipFromParty": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#shipFromParty"
+          },
+          "shipToParty": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#shipToParty"
+          },
+          "tax": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#taxTotalAmount"
+          },
+          "termsOfDelivery": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#specifiedDeliveryTerms"
+          },
+          "termsOfPayment": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#specifiedPaymentTerms"
+          },
+          "totalOrderAmount": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#MonetarySummation"
+          },
+          "totalPaymentDue": {
+            "@id": "https://schema.org/totalPaymentDue"
+          },
+          "totalWeight": {
+            "@id": "https://schema.org/weight"
+          }
+        },
+        "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1001/#Purchase_order"
+      },
+      "PurchaseOrderCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#PurchaseOrderCredential"
+      },
+      "Qualification": {
+        "@context": {
+          "qualificationCategory": {
+            "@id": "https://schema.org/credentialCategory"
+          },
+          "qualificationValue": {
+            "@id": "https://schema.org/hasCredential"
+          }
+        },
+        "@id": "https://schema.org/qualifications"
+      },
+      "QuantitativeValue": {
+        "@context": {
+          "unitCode": {
+            "@id": "https://schema.org/unitCode"
+          },
+          "value": {
+            "@id": "https://schema.org/value"
+          }
+        },
+        "@id": "https://schema.org/QuantitativeValue"
+      },
+      "RawMaterial": {
+        "@context": {
+          "inchiKey": {
+            "@id": "https://w3id.org/traceability#inchiKey"
+          },
+          "name": {
+            "@id": "https://schema.org/name"
+          }
+        },
+        "@id": "https://w3id.org/traceability#RawMaterial"
+      },
+      "RevocationList2020Status": {
+        "@context": {
+          "revocationListCredential": {
+            "@id": "https://schema.org/LinkRole"
+          },
+          "revocationListIndex": {
+            "@id": "https://schema.org/itemListElement"
+          }
+        },
+        "@id": "https://w3id.org/traceability#RevocationList2020Status"
+      },
+      "SIMASteelImportLicense": {
+        "@context": {
+          "applicantCompany": {
+            "@id": "https://schema.org/Organization"
+          },
+          "countryOfExportation": {
+            "@id": "https://schema.org/addressCountry"
+          },
+          "countryOfMeltAndPour": {
+            "@id": "https://w3id.org/traceability#countryOfMeltAndPour"
+          },
+          "countryOfOrigin": {
+            "@id": "https://schema.org/addressCountry"
+          },
+          "customsEntryNumber": {
+            "@id": "https://schema.org/identifier"
+          },
+          "expectedDateOfExport": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#exportExitDateTime"
+          },
+          "expectedDateOfImport": {
+            "@id": "https://w3id.org/traceability#importDateTime"
+          },
+          "expectedPortOfEntry": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#UNECELOCODE"
+          },
+          "exporter": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#exporterParty"
+          },
+          "importer": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#importerParty"
+          },
+          "licenseNumber": {
+            "@id": "https://schema.org/identifier"
+          },
+          "manufacturer": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#manufacturerParty"
+          },
+          "productInformation": {
+            "@id": "https://w3id.org/traceability#productInformation"
+          }
+        },
+        "@id": "https://w3id.org/traceability#SIMASteelImportLicense"
+      },
+      "SIMASteelImportLicenseApplicationCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#SIMASteelImportLicenseApplicationCredential"
+      },
+      "SIMASteelImportLicenseCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#SIMASteelImportLicenseCredential"
+      },
+      "SIMASteelImportProductSpecifier": {
+        "@context": {
+          "customsValue": {
+            "@id": "https://schema.org/MonetaryAmount"
+          },
+          "productCategory": {
+            "@id": "https://w3id.org/traceability#ProductCategory"
+          },
+          "steelProduct": {
+            "@id": "https://w3id.org/traceability#SteelProduct"
+          }
+        },
+        "@id": "https://w3id.org/traceability#SIMASteelImportProductSpecifier"
+      },
+      "SeaCargoManifest": {
+        "@context": {
+          "grossTonnage": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#grossWeightMeasure"
+          },
+          "netTonnage": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#netWeightMeasure"
+          },
+          "plannedArrivalDateTime": {
+            "@id": "https://schema.org/DateTime"
+          },
+          "plannedDepartureDateTime": {
+            "@id": "https://schema.org/Date"
+          },
+          "portOfArrival": {
+            "@id": "https://schema.org/Place"
+          },
+          "portOfDeparture": {
+            "@id": "https://schema.org/Place"
+          },
+          "registrationCountry": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#registrationCountry"
+          },
+          "totalNumberOfPackages": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageQuantity"
+          },
+          "totalNumberOfTransportDocuments": {
+            "@id": "https://schema.org/Number"
+          },
+          "transportDocumentInformation": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#transportContractDocument"
+          },
+          "transportEquipmentQuantity": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#transportEquipmentQuantity"
+          },
+          "vesselName": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#TransportMeans"
+          },
+          "vesselNumber": {
+            "@id": "https://schema.org/identifier"
+          },
+          "voyageNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#TransportMovement"
+          }
+        },
+        "@id": "https://w3id.org/traceability#SeaCargoManifest"
+      },
+      "SeaCargoManifestCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#SeaCargoManifestCredential"
+      },
+      "Seal": {
+        "@context": {
+          "sealNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#seal_number"
+          },
+          "sealSource": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/sealSource"
+          },
+          "sealType": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#sealTypeCode"
+          }
+        },
+        "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#Seal"
+      },
+      "SellerRegistrationCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#SellerRegistrationCredential"
+      },
+      "ServiceCharge": {
+        "@context": {
+          "appliedAmount": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#appliedAmount"
+          },
+          "calculationBasis": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#calculationBasis"
+          },
+          "chargeCode": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#chargeCategoryCode"
+          },
+          "chargeText": {
+            "@id": "https://schema.org/description"
+          },
+          "paymentTerm": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#PaymentTerms"
+          },
+          "rate": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#unitPrice"
+          }
+        },
+        "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#ServiceCharge"
+      },
+      "ShippingInstructions": {
+        "@context": {
+          "billOfLadingNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Bill_of_lading_number"
+          },
+          "bookingNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#carrierAssignedId"
+          },
+          "consignee": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consigneeParty"
+          },
+          "declaredValue": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#declaredValueForCarriageAmount"
+          },
+          "includedConsignmentItems": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#includedConsignmentItem"
+          },
+          "mainCarriageTransportMovement": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#mainCarriageTransportMovement"
+          },
+          "notifyParty": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#notifyParty"
+          },
+          "onCarriageTransportMovement": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#onCarriageTransportMovement"
+          },
+          "placeOfDelivery": {
+            "@id": "https://schema.org/Place"
+          },
+          "placeOfReceipt": {
+            "@id": "https://schema.org/Place"
+          },
+          "portOfDischarge": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#unloadingLocation"
+          },
+          "portOfLoading": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#transshipmentLocation"
+          },
+          "preCarriageTransportMovement": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#preCarriageTransportMovement"
+          },
+          "shipper": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consignorParty"
+          },
+          "shippersReferences": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Consignment_identifier_freight_forwarder_assigned"
+          },
+          "totalNumberOfPackages": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageQuantity"
+          },
+          "transportEquipmentQuantity": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#transportEquipmentQuantity"
+          },
+          "utilizedTransportEquipment": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#utilizedTransportEquipment"
+          }
+        },
+        "@id": "https://w3id.org/traceability#ShippingInstructions"
+      },
+      "ShippingInstructionsCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#ShippingInstructionsCredential"
+      },
+      "ShippingStop": {
+        "@context": {
+          "arrivalDate": {
+            "@id": "https://schema.org/Date"
+          },
+          "carrier": {
+            "@id": "https://schema.org/Organization"
+          },
+          "from": {
+            "@id": "https://schema.org/Place"
+          },
+          "stopType": {
+            "@id": "https://schema.org/description"
+          },
+          "to": {
+            "@id": "https://schema.org/Place"
+          },
+          "vesselNumber": {
+            "@id": "https://schema.org/identifier"
+          }
+        },
+        "@id": "https://w3id.org/traceability#ShippingStop"
+      },
+      "SoftwareBillOfMaterials": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#SoftwareBillOfMaterials"
+      },
+      "SoftwareBillofMaterialsCredential": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#SoftwareBillOfMaterialsCredential"
+      },
+      "SteelProduct": {
+        "@context": {
+          "commodity": {
+            "@id": "https://w3id.org/traceability#Commodity"
+          },
+          "grade": {
+            "@id": "https://schema.org/Rating"
+          },
+          "heatNumber": {
+            "@id": "https://schema.org/identifier"
+          },
+          "inspection": {
+            "@id": "https://w3id.org/traceability#InspectionReport"
+          },
+          "originalCountryOfMeltAndPour": {
+            "@id": "https://schema.org/addressCountry"
+          },
+          "purchase": {
+            "@id": "https://w3id.org/traceability#Purchase"
+          },
+          "shipment": {
+            "@id": "https://schema.org/ParcelDelivery"
+          },
+          "size": {
+            "@id": "https://schema.org/size"
+          },
+          "specification": {
+            "@id": "https://schema.org/identifier"
+          },
+          "weight": {
+            "@id": "https://schema.org/weight"
+          },
+          "weightUnit": {
+            "@id": "http://qudt.org/schema/qudt/Unit"
+          }
+        },
+        "@id": "https://w3id.org/traceability#SteelProduct"
+      },
+      "Taxonomy": {
+        "@context": {
+          "class": {
+            "@id": "http://rs.tdwg.org/dwc/terms/class"
+          },
+          "family": {
+            "@id": "http://rs.tdwg.org/dwc/terms/family"
+          },
+          "genus": {
+            "@id": "http://rs.tdwg.org/dwc/terms/genus"
+          },
+          "kingdom": {
+            "@id": "http://rs.tdwg.org/dwc/terms/kingdom"
+          },
+          "order": {
+            "@id": "http://rs.tdwg.org/dwc/terms/order"
+          },
+          "phylum": {
+            "@id": "http://rs.tdwg.org/dwc/terms/phylum"
+          },
+          "species": {
+            "@id": "http://rs.tdwg.org/dwc/terms/specificEpithet"
+          },
+          "subspecies": {
+            "@id": "http://rs.tdwg.org/dwc/terms/infraspecificEpithet"
+          },
+          "variety": {
+            "@id": "http://rs.tdwg.org/dwc/terms/cultivarEpithet"
+          }
+        },
+        "@id": "https://w3id.org/traceability#Taxonomy"
+      },
+      "TemperatureReading": {
+        "@context": {
+          "bulbNumber": {
+            "@id": "https://schema.org/identifier"
+          },
+          "tests": {
+            "@id": "https://schema.org/value"
+          }
+        },
+        "@id": "https://w3id.org/traceability#TemperatureReading"
+      },
+      "Template": {
+        "@context": {
+          "image": {
+            "@id": "https://schema.org/image"
+          }
+        },
+        "@id": "https://w3id.org/traceability#Template"
+      },
+      "TraceabilityAPI": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#TraceabilityAPI"
+      },
+      "TraceablePresentation": {
+        "@context": {
+          "workflow": {
+            "@id": "https://w3id.org/traceability#Workflow"
+          }
+        },
+        "@id": "https://w3id.org/traceability#TraceablePresentation"
+      },
+      "TradeLineItem": {
+        "@context": {
+          "countryOfOrigin": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#originCountry"
+          },
+          "description": {
+            "@id": "https://schema.org/description"
+          },
+          "grossWeight": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#grossWeightMeasure"
+          },
+          "itemCount": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#despatchedQuantity"
+          },
+          "name": {
+            "@id": "https://schema.org/name"
+          },
+          "netWeight": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#netWeightMeasure"
+          },
+          "packageQuantity": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageQuantity"
+          },
+          "priceSpecification": {
+            "@id": "https://schema.org/priceSpecification"
+          },
+          "product": {
+            "@id": "https://schema.org/Product"
+          },
+          "purchaseOrderNumber": {
+            "@id": "https://schema.org/orderNumber"
+          },
+          "shipToParty": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#shipToParty"
+          }
+        },
+        "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#TradeLineItem"
+      },
+      "TransferEvent": {
+        "@context": {
+          "addressCountry": {
+            "@id": "https://schema.org/addressCountry"
+          },
+          "identifier": {
+            "@id": "https://schema.org/identifier"
+          },
+          "organization": {
+            "@id": "https://w3id.org/traceability#Organization"
+          },
+          "place": {
+            "@id": "https://schema.org/Place"
+          },
+          "price": {
+            "@id": "https://schema.org/price"
+          },
+          "products": {
+            "@id": "https://w3c-ccg.github.io/hashlink/#hl-url-params"
+          }
+        },
+        "@id": "https://w3id.org/traceability#TransferEvent"
+      },
+      "TransformEvent": {
+        "@context": {
+          "consumedProducts": {
+            "@id": "https://w3c-ccg.github.io/hashlink/#hl-url-params"
+          },
+          "newProducts": {
+            "@id": "https://w3c-ccg.github.io/hashlink/#hl-url-params"
+          },
+          "organization": {
+            "@id": "https://w3id.org/traceability#Organization"
+          },
+          "place": {
+            "@id": "https://schema.org/Place"
+          }
+        },
+        "@id": "https://w3id.org/traceability#TransformEvent"
+      },
+      "Transport": {
+        "@context": {
+          "carrier": {
+            "@id": "https://schema.org/Organization"
+          },
+          "dischargeLocation": {
+            "@id": "https://schema.org/Place"
+          },
+          "loadLocation": {
+            "@id": "https://schema.org/Place"
+          },
+          "modeOfTransport": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/modeOfTransport"
+          },
+          "plannedArrivalDate": {
+            "@id": "https://schema.org/Date"
+          },
+          "plannedDepartureDate": {
+            "@id": "https://schema.org/Date"
+          },
+          "vesselNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#TransportMeans"
+          },
+          "voyageNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#TransportMovement"
+          }
+        },
+        "@id": "https://w3id.org/traceability#Transport"
+      },
+      "TransportDocument": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#TransportDocument"
+      },
+      "TransportEquipment": {
+        "@context": {
+          "ISOEquipmentCode": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/ISOEquipmentCode"
+          },
+          "equipmentReference": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#identificationId"
+          },
+          "isShipperOwned": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/isShipperOwned"
+          },
+          "seals": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#affixedSeal"
+          },
+          "tareWeight": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#grossWeightMeasure"
+          },
+          "weightUnit": {
+            "@id": "https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/weightUnit"
+          }
+        },
+        "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#TransportEquipment"
+      },
+      "TransportEvent": {
+        "@context": {
+          "deliveryMethod": {
+            "@id": "https://schema.org/DeliveryMethod"
+          },
+          "organization": {
+            "@id": "https://w3id.org/traceability#Organization"
+          },
+          "place": {
+            "@id": "https://schema.org/Place"
+          },
+          "products": {
+            "@id": "https://w3c-ccg.github.io/hashlink/#hl-url-params"
+          },
+          "trackingNumber": {
+            "@id": "https://schema.org/trackingNumber"
+          }
+        },
+        "@id": "https://w3id.org/traceability#TransportEvent"
+      },
+      "USDAPPQ203ForeignSiteInspection": {
+        "@context": {
+          "certificateNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#identificationId"
+          },
+          "commonInfo": {
+            "@id": "https://w3id.org/traceability#AgricultureInspectionCommonInfo"
+          },
+          "inspectionType": {
+            "@id": "https://www.gs1.org/voc/certificationType"
+          },
+          "observations": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#relatedObservation"
+          },
+          "shipment": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#transportPackage"
+          },
+          "signatureDate": {
+            "@id": "https://www.gs1.org/voc/certificationAuditDate"
+          }
+        },
+        "@id": "https://w3id.org/traceability#USDAPPQ203ForeignSiteInspection"
+      },
+      "USDAPPQ309APestInterceptionRecord": {
+        "@context": {
+          "collectionDate": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#actualOccurrenceDateTime"
+          },
+          "collectionNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#identificationId"
+          },
+          "collector": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#inspectionParty"
+          },
+          "dateReceived": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#acceptanceDateTime"
+          },
+          "finalDetermination": {
+            "@id": "https://dwc.tdwg.org/list/#dwc_identificationID"
+          },
+          "identificationReason": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#reasonCode"
+          },
+          "interceptionSite": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#occurrenceLocation"
+          },
+          "lab": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#lodgementLocation"
+          },
+          "labConformationNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#identificationId"
+          },
+          "priority": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#priorityCode"
+          },
+          "priorityExplanation": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#remarks"
+          },
+          "remarks": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#remarks"
+          },
+          "sampleDisposition": {
+            "@id": "https://dwc.tdwg.org/list/#dwc_disposition"
+          },
+          "signatureDate": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#occurrenceDateTime"
+          },
+          "submissionDate": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#reportSubmissionDateTime"
+          },
+          "submitter": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#senderParty"
+          },
+          "submittingAgency": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#agencyId"
+          },
+          "tentativeDetermination": {
+            "@id": "https://dwc.tdwg.org/list/#dwc_identificationID"
+          }
+        },
+        "@id": "https://w3id.org/traceability#USDAPPQ309APestInterceptionRecord"
+      },
+      "USDAPPQ368NoticeOfArrival": {
+        "@context": {
+          "ITNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#customsIdentificationId"
+          },
+          "arrivalDate": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#actualArrivalRelatedDateTime"
+          },
+          "customsEntryNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#customsIdentificationId"
+          },
+          "locationGrown": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#originLocation"
+          },
+          "permitNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#identificationId"
+          },
+          "ppqOfficial": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#inspectionParty"
+          },
+          "presentLocation": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consignmentDestinationSpecifiedLocation"
+          },
+          "productDisposition": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#dispositionDocument"
+          },
+          "shipment": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#transportPackage"
+          },
+          "signatureDate": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#occurrenceDateTime"
+          }
+        },
+        "@id": "https://w3id.org/traceability#USDAPPQ368NoticeOfArrival"
+      },
+      "USDAPPQ449RTemperatureCalibration": {
+        "@context": {
+          "cableLengthSatisfactory": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#reportedStatus"
+          },
+          "company": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#specifiedOrganization"
+          },
+          "flagCode": {
+            "@id": "https://schema.org/value"
+          },
+          "hullNumberDockyard": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#identificationId"
+          },
+          "imoNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#identificationId"
+          },
+          "inspectionDate": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#performanceDateTime"
+          },
+          "inspectionPoint": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#transitLocation"
+          },
+          "instrument1MakeModel": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#attachedTransportEquipment"
+          },
+          "instrument2MakeModel": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#attachedTransportEquipment"
+          },
+          "locationsDiagramMatchSatisfactory": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#reportedStatus"
+          },
+          "ownerOperator": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#specifiedPerson"
+          },
+          "participatingOfficials": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#specifiedPerson"
+          },
+          "ppqDutyStation": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#transitCustomsOfficeSpecifiedLocation"
+          },
+          "reactionTimeSatisfactory": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#reportedStatus"
+          },
+          "remarks": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#remarks"
+          },
+          "sensorsBoxesLabelingSatisfactory": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#reportedStatus"
+          },
+          "shipsOfficer": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#specifiedPerson"
+          },
+          "signatureDate": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#performanceDateTime"
+          },
+          "temperatureReadings": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#transportTemperature"
+          },
+          "vesselName": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#name"
+          }
+        },
+        "@id": "https://w3id.org/traceability#USDAPPQ449RTemperatureCalibration"
+      },
+      "USDAPPQ519ComplianceAgreement": {
+        "@context": {
+          "agreement": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#guarantee"
+          },
+          "agreementDate": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#issueDateTime"
+          },
+          "agreementNumber": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#issueDateTime"
+          },
+          "firm": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#associatedParty"
+          },
+          "person": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#associatedParty"
+          },
+          "ppqCbpOfficial": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#associatedParty"
+          },
+          "quarantinesRegulations": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#applicableRegulatoryProcedure"
+          },
+          "regulatedArticles": {
+            "@id": "https://www.gs1.org/voc/regulatedProductName"
+          },
+          "signatureDate": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#issueDateTime"
+          },
+          "usAgencyOfficial": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#associatedParty"
+          }
+        },
+        "@id": "https://w3id.org/traceability#USDAPPQ519ComplianceAgreement"
+      },
+      "USDAPPQ587PlantImportPermit": {
+        "@context": {
+          "applicant": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#associatedParty"
+          },
+          "intendedUse": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#intendedUse"
+          },
+          "shipment": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#transportPackage"
+          },
+          "signatureDate": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#issueDateTime"
+          }
+        },
+        "@id": "https://w3id.org/traceability#USDAPPQ587PlantImportPermit"
+      },
+      "USDASpecialtyCrops237AForm": {
+        "@context": {
+          "additionalRemarks": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#remarks"
+          },
+          "anticipatedAuditDate": {
+            "@id": "https://www.gs1.org/voc/certificationAuditDate"
+          },
+          "applicant": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#associatedParty"
+          },
+          "auditProgramsRequested": {
+            "@id": "https://www.gs1.org/voc/certificationType"
+          },
+          "auditee": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#associatedParty"
+          },
+          "billingAccountNumber": {
+            "@id": "https://schema.org/accountId"
+          },
+          "commoditiesCovered": {
+            "@id": "https://www.gs1.org/voc/certificationSubject"
+          },
+          "locations": {
+            "@id": "https://schema.org/location"
+          },
+          "requestDate": {
+            "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#reportSubmissionDateTime"
+          },
+          "totalArea": {
+            "@id": "https://www.gs1.org/voc/grossArea"
+          }
+        },
+        "@id": "https://w3id.org/traceability#USDASpecialtyCrops237AForm"
+      },
+      "USMCACertificationOfOrigin": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#USMCACertificationOfOrigin"
+      },
+      "USMCACertifier": {
+        "@context": {
+          "certifierDetails": {
+            "@id": "https://w3id.org/traceability#certifierDetails"
+          },
+          "role": {
+            "@id": "https://w3id.org/traceability#certifierRole"
+          }
+        },
+        "@id": "https://w3id.org/traceability/USMCACertifier"
+      },
+      "USMCAProductSpecifier": {
+        "@context": {
+          "countryOfOrigin": {
+            "@id": "https://w3id.org/traceability#countryOfOrigin"
+          },
+          "exporterDetails": {
+            "@id": "https://w3id.org/traceability#exporterDetails"
+          },
+          "importerDetails": {
+            "@id": "https://w3id.org/traceability#importerDetails"
+          },
+          "importerUnknown": {
+            "@id": "https://w3id.org/traceability#importerUnknown"
+          },
+          "originCriterion": {
+            "@id": "https://w3id.org/traceability#originCriterion"
+          },
+          "producerConfidential": {
+            "@id": "https://w3id.org/traceability#producerConfidential"
+          },
+          "producerDetails": {
+            "@id": "https://schema.org/manufacturer"
+          },
+          "product": {
+            "@id": "https://schema.org/Product"
+          }
+        },
+        "@id": "https://w3id.org/traceability/USMCAProductSpecifier"
+      },
+      "UsdaSc6": {
+        "@context": {
+          "applicant": {
+            "@id": "https://w3id.org/traceability#applicant"
+          },
+          "carrierId": {
+            "@id": "https://w3id.org/traceability#carrierId"
+          },
+          "customsEntryNumber": {
+            "@id": "https://w3id.org/traceability#customsEntryNumber"
+          },
+          "dateOfEntry": {
+            "@id": "https://w3id.org/traceability#dateOfEntry"
+          },
+          "facility": {
+            "@id": "https://www.gs1.org/voc/Place"
+          },
+          "importerSignatureDate": {
+            "@id": "https://w3id.org/traceability#importerSignatureDate"
+          },
+          "inspectionDate": {
+            "@id": "https://schema.org/DateTime"
+          },
+          "inspector": {
+            "@id": "https://w3id.org/traceability#Inspector"
+          },
+          "intendedUse": {
+            "@id": "https://w3id.org/traceability#intendedUse"
+          },
+          "intendedUseCert": {
+            "@id": "https://w3id.org/traceability#intendedUseCert"
+          },
+          "lotId": {
+            "@id": "https://w3id.org/traceability#lotId"
+          },
+          "serialNumber": {
+            "@id": "https://w3id.org/traceability#serialNumber"
+          },
+          "shipment": {
+            "@id": "https://w3id.org/traceability#AgricultureParcelDelivery"
+          },
+          "signatureDate": {
+            "@id": "https://w3id.org/traceability#signatureDate"
+          },
+          "tariffCodeNumber": {
+            "@id": "https://w3id.org/traceability#tariffCodeNumber"
+          }
+        },
+        "@id": "https://w3id.org/traceability#UsdaSc6"
+      },
+      "VerifiableBusinessCard": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#VerifiableBusinessCard"
+      },
+      "VerifiablePostmanCollection": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#VerifiablePostmanCollection"
+      },
+      "VerifiableScorecard": {
+        "@context": {},
+        "@id": "https://w3id.org/traceability#VerifiableScorecard"
+      },
+      "Workflow": {
+        "@context": {
+          "definition": {
+            "@id": "https://w3id.org/traceability/#workflow-definition"
+          },
+          "instance": {
+            "@id": "https://w3id.org/traceability/#workflow-instance"
+          }
+        },
+        "@id": "https://w3id.org/traceability#Workflow"
+      },
+      "dateOfExport": {
+        "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#exportExitDateTime",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "description": "https://schema.org/description",
+      "id": "@id",
+      "identifier": "https://schema.org/identifier",
+      "image": {
+        "@id": "https://schema.org/image",
+        "@type": "@id"
+      },
+      "items": "https://schema.org/ItemList",
+      "manufacturer": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#manufacturerParty",
+      "manufacturingCountry": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#manufactureCountry",
+      "name": "https://schema.org/name",
+      "product": "https://w3id.org/traceability#SteelProduct",
+      "rawMaterial": "https://w3id.org/traceability#rawMaterial",
+      "relatedLink": {
+        "@id": "https://w3id.org/traceability#LinkRole"
+      },
+      "type": "@type"
+    }
+  }

--- a/tests/update_conformance_vcs.js
+++ b/tests/update_conformance_vcs.js
@@ -4,6 +4,7 @@ const { CONTEXT_URL, CONTEXT } = require('credentials-context');
 const jsonld = require('jsonld');
 const { strictDocumentLoader } = require('jsonld-signatures');
 const { klona } = require('klona/json');
+const fs = require('fs');
 
 // If this changes, the `issuer` in `valid-credential.json` must be updated to
 // match. In order for signed credentials to be valid, the controller for a
@@ -49,6 +50,17 @@ const mutatingDocumentLoader = async ({ mutate = noopMutator } = {}) => {
       return {
         contextUrl: null,
         document: mutate(klona(CONTEXT)),
+        documentUrl: url,
+      };
+    }
+
+    if (url && url == 'https://w3id.org/traceability/v1') {
+      let context = fs.readFileSync('./traceability-v1.jsonld', 'utf8');
+      context = JSON.parse(context);
+      return {
+        contextUrl: null,
+        // Don't mutate traceability context
+        document: klona(context),
         documentUrl: url,
       };
     }

--- a/tests/valid-credential.json
+++ b/tests/valid-credential.json
@@ -1,5 +1,5 @@
 {
-  "@context": ["https://www.w3.org/2018/credentials/v1"],
+  "@context": ["https://www.w3.org/2018/credentials/v1", "https://w3id.org/traceability/v1"],
   "credentialSubject": {
     "id": "did:example:123"
   },


### PR DESCRIPTION
This PR adds negative testing to ensure failure when a credential presented to `/credentials/issue` does not contain the required context entry, as well as positive testing that fails if a response to `/credentials/issue` contains a verifiable credential without the required context entry.

Fixes #474 