### PR TITLE
chore: make verifications required in verification result

### DIFF
--- a/docs/openapi/schemas/Verification.yml
+++ b/docs/openapi/schemas/Verification.yml
@@ -4,15 +4,16 @@ properties:
   title:
     type: string
     enum: 
-      - Proof
       - Activation
       - Expired
+      - Proof
       - Revocation
+      - Signature
   status:
     type: string
     enum: 
-      - good
-      - bad
+      - Passed
+      - Failed
   description:
     type: string
 required: 
@@ -21,6 +22,6 @@ required:
 example:
   {
       "title": "Activation",
-      "status": "good",
+      "status": "Passed",
       "description": "This credential activated 2 weeks ago"
   }

--- a/docs/openapi/schemas/Verification.yml
+++ b/docs/openapi/schemas/Verification.yml
@@ -12,8 +12,8 @@ properties:
   status:
     type: string
     enum: 
-      - Passed
-      - Failed
+      - good
+      - bad
   description:
     type: string
 required: 
@@ -22,6 +22,6 @@ required:
 example:
   {
       "title": "Activation",
-      "status": "Passed",
+      "status": "good",
       "description": "This credential activated 2 weeks ago"
   }

--- a/docs/openapi/schemas/VerificationResult.yml
+++ b/docs/openapi/schemas/VerificationResult.yml
@@ -15,24 +15,24 @@ example:
     "verified": true,
     "verifications": [
         {
-            "status": "Passed",
+            "status": "good",
             "title": "Activation",
             "description": "This credential activated 2 weeks ago"
         },
         {
-            "status": "Passed",
+            "status": "good",
             "title": "Expired"
         },
         {
-            "status": "Passed",
+            "status": "good",
             "title": "Proof"
         },
         {
-            "status": "Passed",
+            "status": "good",
             "title": "Revocation"
         },
         {
-            "status": "Passed",
+            "status": "good",
             "title": "Signature",
             "description": "did:key:ni5kvh48ZRcVN2gfs6cteK8M1JzJdcwcYJak5R7VkhXeqsHn#z6Mkvh48ZRcVN2gfs6cteK8M1JzJdcwcYJak5R7VkhXeqsHn"
         }

--- a/docs/openapi/schemas/VerificationResult.yml
+++ b/docs/openapi/schemas/VerificationResult.yml
@@ -9,17 +9,30 @@ properties:
       $ref: ./Verification.yml
 required: 
   - verified
+  - verifications
 example: 
   {
     "verified": true,
     "verifications": [
         {
-            "status": "good",
+            "status": "Passed",
             "title": "Activation",
             "description": "This credential activated 2 weeks ago"
         },
         {
-            "status": "good",
+            "status": "Passed",
+            "title": "Expired"
+        },
+        {
+            "status": "Passed",
+            "title": "Proof"
+        },
+        {
+            "status": "Passed",
+            "title": "Revocation"
+        },
+        {
+            "status": "Passed",
             "title": "Signature",
             "description": "did:key:ni5kvh48ZRcVN2gfs6cteK8M1JzJdcwcYJak5R7VkhXeqsHn#z6Mkvh48ZRcVN2gfs6cteK8M1JzJdcwcYJak5R7VkhXeqsHn"
         }

--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -15657,7 +15657,7 @@
 		},
 		{
 			"key": "responseSchema200CredentialsVerify",
-			"value": "{\"title\":\"Verification Result\",\"type\":\"object\",\"properties\":{\"verified\":{\"type\":\"boolean\"},\"verifications\":{\"type\":\"array\",\"items\":{\"title\":\"Verification\",\"type\":\"object\",\"properties\":{\"title\":{\"type\":\"string\",\"enum\":[\"Activation\",\"Expired\",\"Proof\",\"Revocation\",\"Signature\"]},\"status\":{\"type\":\"string\",\"enum\":[\"Passed\",\"Failed\"]},\"description\":{\"type\":\"string\"}},\"required\":[\"title\",\"status\"]}}},\"required\":[\"verified\",\"verifications\"]}",
+			"value": "{\"title\":\"Verification Result\",\"type\":\"object\",\"properties\":{\"verified\":{\"type\":\"boolean\"},\"verifications\":{\"type\":\"array\",\"items\":{\"title\":\"Verification\",\"type\":\"object\",\"properties\":{\"title\":{\"type\":\"string\",\"enum\":[\"Activation\",\"Expired\",\"Proof\",\"Revocation\",\"Signature\"]},\"status\":{\"type\":\"string\",\"enum\":[\"good\",\"bad\"]},\"description\":{\"type\":\"string\"}},\"required\":[\"title\",\"status\"]}}},\"required\":[\"verified\",\"verifications\"]}",
 			"type": "string"
 		},
 		{

--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -15657,7 +15657,7 @@
 		},
 		{
 			"key": "responseSchema200CredentialsVerify",
-			"value": "{\"title\":\"Verification Result\",\"type\":\"object\",\"properties\":{\"verified\":{\"type\":\"boolean\"},\"verifications\":{\"type\":\"array\",\"items\":{\"title\":\"Verification\",\"type\":\"object\",\"properties\":{\"title\":{\"type\":\"string\",\"enum\":[\"Proof\",\"Activation\",\"Expired\",\"Revocation\"]},\"status\":{\"type\":\"string\",\"enum\":[\"good\",\"bad\"]},\"description\":{\"type\":\"string\"}},\"required\":[\"title\",\"status\"]}}},\"required\":[\"verified\"]}",
+			"value": "{\"title\":\"Verification Result\",\"type\":\"object\",\"properties\":{\"verified\":{\"type\":\"boolean\"},\"verifications\":{\"type\":\"array\",\"items\":{\"title\":\"Verification\",\"type\":\"object\",\"properties\":{\"title\":{\"type\":\"string\",\"enum\":[\"Activation\",\"Expired\",\"Proof\",\"Revocation\",\"Signature\"]},\"status\":{\"type\":\"string\",\"enum\":[\"Passed\",\"Failed\"]},\"description\":{\"type\":\"string\"}},\"required\":[\"title\",\"status\"]}}},\"required\":[\"verified\",\"verifications\"]}",
 			"type": "string"
 		},
 		{


### PR DESCRIPTION
This PR makes the `verifications` array in the [VerificationResult.yaml](https://github.com/w3c-ccg/traceability-interop/blob/main/docs/openapi/schemas/VerificationResult.yml) object required. The array can be empty, but it must be present.

Additionally, `Signature` has been added as an enum value for the `title` property of a `verifications` array item, `status` values `good` and `bad` have been changed to `Passed` and `Failed` respectively, and an entry for each of the possible `title` enum values has been added to the example verification result.

Fixes #469
Fixes #470 

