### PR TITLE
Get credential error schema

### DIFF
--- a/docs/openapi/resources/credential.yml
+++ b/docs/openapi/resources/credential.yml
@@ -23,6 +23,6 @@ get:
     '403':
       $ref: '../responses/Unauthorized.yml'
     '404':
-      description: Credential not found
+      $ref: '../responses/NotFound.yml'
     default:
       $ref: "../responses/UnexpectedError.yml"


### PR DESCRIPTION
I don't see why getCredential 404 shouldn't be pulling from the common NotFound error. Seems inconsistent. 

Ref https://github.com/w3c-ccg/vc-api/pull/326