### PR TITLE
fix: store nested VC and VP data for later use

### DIFF
--- a/docs/tutorials/credentials-revocation/credentials-revocation.postman_collection.json
+++ b/docs/tutorials/credentials-revocation/credentials-revocation.postman_collection.json
@@ -203,10 +203,9 @@
 							"",
 							"// Verifiable credential must be made available to later requests",
 							"pm.test(\"`verifiable_credential` persisted to collectionVariables\", function() {",
-							"    const verifiable_credential = JSON.stringify(pm.response.json());",
-							"    pm.collectionVariables.set(\"verifiable_credential\", verifiable_credential);",
-							"})",
-							""
+							"    const {verifiableCredential} = pm.response.json();",
+							"    pm.collectionVariables.set(\"verifiable_credential\", JSON.stringify(verifiableCredential));",
+							"});"
 						],
 						"type": "text/javascript"
 					}

--- a/docs/tutorials/credentials-verify/credentials-verify.postman_collection.json
+++ b/docs/tutorials/credentials-verify/credentials-verify.postman_collection.json
@@ -202,10 +202,9 @@
 							"",
 							"// Verifiable credential must be made available to later requests",
 							"pm.test(\"`verifiable_credential` persisted to collectionVariables\", function() {",
-							"    const verifiable_credential = JSON.stringify(pm.response.json());",
-							"    pm.collectionVariables.set(\"verifiable_credential\", verifiable_credential);",
-							"})",
-							""
+							"    const {verifiableCredential} = pm.response.json();",
+							"    pm.collectionVariables.set(\"verifiable_credential\", JSON.stringify(verifiableCredential));",
+							"})"
 						],
 						"type": "text/javascript"
 					}

--- a/docs/tutorials/mill-test-report-certificate/vc-api.mtrc.collection.json
+++ b/docs/tutorials/mill-test-report-certificate/vc-api.mtrc.collection.json
@@ -120,9 +120,8 @@
 					"listen": "test",
 					"script": {
 						"exec": [
-							"const verifiableCredential = pm.response.json()",
-							"pm.environment.set(\"mill_test_report_certificate\", JSON.stringify(verifiableCredential));",
-							""
+							"const {verifiableCredential} = pm.response.json();",
+							"pm.environment.set(\"mill_test_report_certificate\", JSON.stringify(verifiableCredential));"
 						],
 						"type": "text/javascript"
 					}

--- a/docs/tutorials/presentations-exchange/presentations-exchange.postman_collection.json
+++ b/docs/tutorials/presentations-exchange/presentations-exchange.postman_collection.json
@@ -412,9 +412,9 @@
 							"",
 							"// Verifiable credential must be made available to later requests",
 							"pm.test(\"`verifiable_credential` persisted to collectionVariables\", function() {",
-							"    const verifiable_credential = JSON.stringify(pm.response.json());",
-							"    pm.collectionVariables.set(\"verifiable_credential\", verifiable_credential);",
-							"})"
+							"    const {verifiableCredential} = pm.response.json();",
+							"    pm.collectionVariables.set(\"verifiable_credential\", JSON.stringify(verifiableCredential));",
+							"});"
 						],
 						"type": "text/javascript"
 					}
@@ -600,9 +600,9 @@
 							"",
 							"// Verifiable presentation must be made available to later requests",
 							"pm.test(\"`verifiable_presentation` persisted to collectionVariables\", function() {",
-							"    const verifiable_presentation = JSON.stringify(pm.response.json());",
-							"    pm.collectionVariables.set(\"verifiable_presentation\", verifiable_presentation);",
-							"})"
+							"    const {verifiablePresentation} = pm.response.json();",
+							"    pm.collectionVariables.set(\"verifiable_presentation\", JSON.stringify(verifiablePresentation));",
+							"});"
 						],
 						"type": "text/javascript"
 					}

--- a/docs/tutorials/presentations-verify/presentations-verify.postman_collection.json
+++ b/docs/tutorials/presentations-verify/presentations-verify.postman_collection.json
@@ -362,9 +362,9 @@
 							"",
 							"// Verifiable credential must be made available to later requests",
 							"pm.test(\"`verifiable_credential` persisted to collectionVariables\", function() {",
-							"    const verifiable_credential = JSON.stringify(pm.response.json());",
-							"    pm.collectionVariables.set(\"verifiable_credential\", verifiable_credential);",
-							"})"
+							"    const {verifiableCredential} = pm.response.json();",
+							"    pm.collectionVariables.set(\"verifiable_credential\", JSON.stringify(verifiableCredential));",
+							"});"
 						],
 						"type": "text/javascript"
 					}
@@ -550,9 +550,9 @@
 							"",
 							"// Verifiable presentation must be made available to later requests",
 							"pm.test(\"`verifiable_presentation` persisted to collectionVariables\", function() {",
-							"    const verifiable_presentation = JSON.stringify(pm.response.json());",
-							"    pm.collectionVariables.set(\"verifiable_presentation\", verifiable_presentation);",
-							"})"
+							"    const {verifiablePresentation} = pm.response.json();",
+							"    pm.collectionVariables.set(\"verifiable_presentation\", JSON.stringify(verifiablePresentation));",
+							"});"
 						],
 						"type": "text/javascript"
 					}

--- a/docs/tutorials/report-generation/report-tester.collection.json
+++ b/docs/tutorials/report-generation/report-tester.collection.json
@@ -76,7 +76,7 @@
 					"listen": "test",
 					"script": {
 						"exec": [
-							"const verifiableCredential = pm.response.json()",
+							"const {verifiableCredential} = pm.response.json();",
 							"",
 							"pm.test(\"The Verifiable Credential MUST have a 'proof'\", function () {",
 							"    pm.expect(verifiableCredential.proof).to.be.an(\"object\");",

--- a/docs/tutorials/workflow-join/workflow-instance-join.collection.json
+++ b/docs/tutorials/workflow-join/workflow-instance-join.collection.json
@@ -398,8 +398,9 @@
 						"exec": [
 							"  pm.test(\"Proforma Invoice VC issued\", function () {",
 							"      pm.response.to.have.status(201);",
-							"      pm.collectionVariables.set('importers_proforma_invoice_vc', JSON.stringify(pm.response.json()));",
-							"  })"
+							"      const {verifiableCredential} = pm.response.json();",
+							"      pm.collectionVariables.set('importers_proforma_invoice_vc', JSON.stringify(verifiableCredential));",
+							"  });"
 						],
 						"type": "text/javascript"
 					}
@@ -509,8 +510,8 @@
 					"listen": "test",
 					"script": {
 						"exec": [
-							"const responseJson = pm.response.json();",
-							"pm.collectionVariables.set(\"importers_proforma_invoice_presented_to_customs\", JSON.stringify(responseJson));",
+							"const {verifiablePresentation} = pm.response.json();",
+							"pm.collectionVariables.set(\"importers_proforma_invoice_presented_to_customs\", JSON.stringify(verifiablePresentation));",
 							"",
 							"pm.test(\"Importer VP of Proforma Invoice with workflow instance 'instance_1' proved\", function () {",
 							"    pm.response.to.have.status(201);",
@@ -704,8 +705,9 @@
 						"exec": [
 							"  pm.test(\"House Bill of Lading VC issued\", function () {",
 							"      pm.response.to.have.status(201);",
-							"      pm.collectionVariables.set('freight_forwarders_hbol_vc', JSON.stringify(pm.response.json()));",
-							"  })"
+							"      const {verifiableCredential} = pm.response.json();",
+							"      pm.collectionVariables.set('freight_forwarders_hbol_vc', JSON.stringify(verifiableCredential));",
+							"  });"
 						],
 						"type": "text/javascript"
 					}
@@ -815,8 +817,8 @@
 					"listen": "test",
 					"script": {
 						"exec": [
-							"const responseJson = pm.response.json();",
-							"pm.collectionVariables.set(\"freight_forwarders_house_bill_presented_to_customs\", JSON.stringify(responseJson));",
+							"const {verifiablePresentation} = pm.response.json();",
+							"pm.collectionVariables.set(\"freight_forwarders_house_bill_presented_to_customs\", JSON.stringify(verifiablePresentation));",
 							"",
 							"pm.test(\"Freight Forwarder VP of House Bill of Lading with workflow instance 'instance_2' proved\", function () {",
 							"    pm.response.to.have.status(201);",
@@ -1009,8 +1011,9 @@
 						"exec": [
 							"  pm.test(\"Commercial Invoice VC issued\", function () {",
 							"      pm.response.to.have.status(201);",
-							"      pm.collectionVariables.set('importers_commercial_invoice_vc', JSON.stringify(pm.response.json()));",
-							"  })"
+							"      const {verifiableCredential} = pm.response.json();",
+							"      pm.collectionVariables.set('importers_commercial_invoice_vc', JSON.stringify(verifiableCredential));",
+							"  });"
 						],
 						"type": "text/javascript"
 					}
@@ -1120,8 +1123,8 @@
 					"listen": "test",
 					"script": {
 						"exec": [
-							"const responseJson = pm.response.json();",
-							"pm.collectionVariables.set(\"importers_presentation_of_ci_to_freight_forwarder\", JSON.stringify(responseJson));",
+							"const {verifiablePresentation} = pm.response.json();",
+							"pm.collectionVariables.set(\"importers_presentation_of_ci_to_freight_forwarder\", JSON.stringify(verifiablePresentation));",
 							"",
 							"pm.test(\"Importer VP of Commercial Invoice with workflow instance 'instance_1' proved\", function () {",
 							"    pm.response.to.have.status(201);",
@@ -1317,8 +1320,8 @@
 					"listen": "test",
 					"script": {
 						"exec": [
-							"const responseJson = pm.response.json();",
-							"pm.collectionVariables.set(\"freight_forwarders_presentation_of_ci_to_customs\", JSON.stringify(responseJson));",
+							"const {verifiablePresentation} = pm.response.json();",
+							"pm.collectionVariables.set(\"freight_forwarders_presentation_of_ci_to_customs\", JSON.stringify(verifiablePresentation));",
 							"",
 							"pm.test(\"Freight Forwarder VP of Commercial Invoice with workflow instances 'instance_1' and 'instance_2' proved\", function () {",
 							"    pm.response.to.have.status(201);",


### PR DESCRIPTION
This PR fixes a regression caused when the responses to `/credentials/issue` and `/presentations/prove` started being nested under top-level `verifiableCredential` and `verifiablePresentation` elements respectively.

Fixex #488 