### PR TITLE
Fix Conflict Conformance Tests (`credentials_verify:vc:id:missing` and `credentials_verify:bad_signature`)

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -612,6 +612,72 @@
 									"response": []
 								},
 								{
+									"name": "credentials_issue:credential.@context:invalid",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // \"credential.@context\" must contain \"https://w3id.org/traceability/v1\"",
+													"    req.credential[\"@context\"] = [\"https://www.w3.org/2018/credentials/v1\"];",
+													"}));",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/issue",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"issue"
+											]
+										}
+									},
+									"response": []
+								},
+								{
 									"name": "credentials_issue:credential.@context:boolean",
 									"event": [
 										{


### PR DESCRIPTION
This PR is for this issue reported here: https://github.com/w3c-ccg/traceability-interop/issues/510

This test also removes the `credentials_issue:credential.@context:invalid` that enforces all credentials must have `https://w3id.org/traceability/v1` in it's context.