### PR TITLE
build: remove MESUR_IO_DEV from conformance suite

### DIFF
--- a/.github/workflows/conformance-run.yml
+++ b/.github/workflows/conformance-run.yml
@@ -23,8 +23,6 @@ jobs:
             actor: "MAVENNET_STAGING"
           - name: "mesur.io"
             actor: "MESUR_IO_PRODUCTION"
-          - name: "dev.mesur.io"
-            actor: "MESUR_IO_DEV"
           - name: "Transmute"
             actor: "TRANSMUTE_PRODUCTION"
           - name: "GS1US"


### PR DESCRIPTION
This PR removes the legacy MESUR_IO_DEV implementation from conformance testing.