### PR TITLE
fix: add request bodies to negative tests

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -6534,7 +6534,10 @@
 											"script": {
 												"exec": [
 													"// Request body must be serialized before sending over the wire.",
-													"pm.variables.set(\"requestBody\", JSON.stringify(pm.variables.get(\"rawBody\")));"
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // noop",
+													"}));",
+													""
 												],
 												"type": "text/javascript"
 											}
@@ -6602,7 +6605,10 @@
 													"utils(pm).getAccessToken('');",
 													"",
 													"// Request body must be serialized before sending over the wire.",
-													"pm.variables.set(\"requestBody\", JSON.stringify(pm.variables.get(\"rawBody\")));"
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // noop",
+													"}));",
+													""
 												],
 												"type": "text/javascript"
 											}
@@ -9347,7 +9353,10 @@
 											"listen": "prerequest",
 											"script": {
 												"exec": [
-													""
+													"// Request body must be serialized before sending over the wire.",
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // noop",
+													"}));"
 												],
 												"type": "text/javascript"
 											}
@@ -9373,6 +9382,15 @@
 									"request": {
 										"method": "POST",
 										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
 										"url": {
 											"raw": "{{API_BASE_URL}}/credentials/status",
 											"host": [
@@ -9395,7 +9413,11 @@
 												"exec": [
 													"// Obtain an access token without the required \"update:credentials\" scope",
 													"utils(pm).getAccessToken('');",
-													""
+													"",
+													"// Request body must be serialized before sending over the wire.",
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // noop",
+													"}));"
 												],
 												"type": "text/javascript"
 											}
@@ -9431,6 +9453,15 @@
 										},
 										"method": "POST",
 										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
 										"url": {
 											"raw": "{{API_BASE_URL}}/credentials/status",
 											"host": [
@@ -15007,6 +15038,11 @@
 													"const didDoc = pm.variables.get(\"currentDidWeb\");",
 													"const service = didDoc.service.find((s) => s.type.includes('TraceabilityAPI'));",
 													"pm.variables.set(\"presentations_base_url\", service.serviceEndpoint);",
+													"",
+													"// Request body must be serialized before sending over the wire.",
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // noop",
+													"}));",
 													""
 												],
 												"type": "text/javascript"
@@ -15033,6 +15069,15 @@
 									"request": {
 										"method": "POST",
 										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
 										"url": {
 											"raw": "{{presentations_base_url}}/presentations/prove",
 											"host": [
@@ -15060,7 +15105,11 @@
 													"const didDoc = pm.variables.get(\"currentDidWeb\");",
 													"const service = didDoc.service.find((s) => s.type.includes('TraceabilityAPI'));",
 													"pm.variables.set(\"presentations_base_url\", service.serviceEndpoint);",
-													""
+													"",
+													"// Request body must be serialized before sending over the wire.",
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // noop",
+													"}));"
 												],
 												"type": "text/javascript"
 											}
@@ -15096,6 +15145,15 @@
 										},
 										"method": "POST",
 										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
 										"url": {
 											"raw": "{{presentations_base_url}}/presentations/prove",
 											"host": [
@@ -15155,7 +15213,24 @@
 							"// fires off an async sendRequest() that Postman will wait for before running",
 							"// any requests in the collection.",
 							"utils(pm).populateCurrentDidWeb(pm.environment.get(\"ORGANIZATION_DID_WEB\"));",
-							""
+							"",
+							"// Minimal request body should represent the minimum set of data required",
+							"// for a successful request. This should exclude all optional items, and",
+							"// should contain the first alternate version of any 'oneOf' elements",
+							"// defined in the OpenAPI schema.",
+							"//",
+							"// Tests will use this minimal request body as a starting point and will",
+							"// mutate it as needed in pre-request scripts, e.g., to run tests using",
+							"// alternate or optional elements.",
+							"",
+							"pm.variables.set(\"minimalRequestBody\", {",
+							"});",
+							"",
+							"mutateRequestBody = (mutationFunction) => {",
+							"    const req = pm.variables.get(\"minimalRequestBody\");",
+							"    mutationFunction(req);",
+							"    return JSON.stringify(req);",
+							"};"
 						]
 					}
 				},
@@ -15190,6 +15265,11 @@
 													"const didDoc = pm.variables.get(\"currentDidWeb\");",
 													"const service = didDoc.service.find((s) => s.type.includes('TraceabilityAPI'));",
 													"pm.variables.set(\"presentations_base_url\", service.serviceEndpoint);",
+													"",
+													"// Request body must be serialized before sending over the wire.",
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // noop",
+													"}));",
 													""
 												],
 												"type": "text/javascript"
@@ -15216,6 +15296,15 @@
 									"request": {
 										"method": "POST",
 										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
 										"url": {
 											"raw": "{{presentations_base_url}}/presentations/verify",
 											"host": [
@@ -15243,7 +15332,11 @@
 													"const didDoc = pm.variables.get(\"currentDidWeb\");",
 													"const service = didDoc.service.find((s) => s.type.includes('TraceabilityAPI'));",
 													"pm.variables.set(\"presentations_base_url\", service.serviceEndpoint);",
-													""
+													"",
+													"// Request body must be serialized before sending over the wire.",
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // noop",
+													"}));"
 												],
 												"type": "text/javascript"
 											}
@@ -15279,6 +15372,15 @@
 										},
 										"method": "POST",
 										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
 										"url": {
 											"raw": "{{presentations_base_url}}/presentations/verify",
 											"host": [
@@ -15338,7 +15440,24 @@
 							"// fires off an async sendRequest() that Postman will wait for before running",
 							"// any requests in the collection.",
 							"utils(pm).populateCurrentDidWeb(pm.environment.get(\"ORGANIZATION_DID_WEB\"));",
-							""
+							"",
+							"// Minimal request body should represent the minimum set of data required",
+							"// for a successful request. This should exclude all optional items, and",
+							"// should contain the first alternate version of any 'oneOf' elements",
+							"// defined in the OpenAPI schema.",
+							"//",
+							"// Tests will use this minimal request body as a starting point and will",
+							"// mutate it as needed in pre-request scripts, e.g., to run tests using",
+							"// alternate or optional elements.",
+							"",
+							"pm.variables.set(\"minimalRequestBody\", {",
+							"});",
+							"",
+							"mutateRequestBody = (mutationFunction) => {",
+							"    const req = pm.variables.get(\"minimalRequestBody\");",
+							"    mutationFunction(req);",
+							"    return JSON.stringify(req);",
+							"};"
 						]
 					}
 				},


### PR DESCRIPTION
This PR ensures that negative authentication and authorization tests only fail for one reason. There were several tests that were not updated after we implemented request body mutation, and these were still trying to reference old (removed) variables resulting in an empty request body.

Other tests (presentation related) were not sending any request body at all and have been upgrade to start using request body mutation with the current behavior to send an empty JSON object.