### PR TITLE
docs: add editor email addresses

### DIFF
--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -49,18 +49,36 @@
           url: 'https://github.com/OR13',
           company: 'Transmute',
           companyURL: 'https://www.transmute.industries/',
+          extras: [
+            {
+              name: "E-mail",
+              href: "mailto:orie@transmute.industries"
+            }
+          ]
         },
         {
           name: 'Michael Prorock',
           url: 'https://github.com/mprorock',
           company: 'Mesur.io',
           companyURL: 'https://mesur.io/',
+          extras: [
+            {
+              name: "E-mail",
+              href: "mailto:mprorock@mesur.io"
+            }
+          ]
         },
         {
           name: 'Mahmoud Alkhraishi',
           url: 'https://github.com/mkhraisha',
           company: 'Mavennet',
           companyURL: 'https://www.mavennet.com/',
+          extras: [
+            {
+              name: "E-mail",
+              href: "mailto:mahmoud@mavennet.com"
+            }
+          ]
         },
       ],
 


### PR DESCRIPTION
This PR adds email addresses for the spec editors.

---

![image](https://user-images.githubusercontent.com/755209/223501679-2fc62b60-0960-4267-a05b-f12b51157f2f.png)

Fixes #492