### PR TITLE
refactor: relax specific scope naming requirements

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "a8035051-bb5b-4670-abe3-cfb96bc141e9",
+		"_postman_id": "e9c7f21a-ef69-4217-8f40-0424834c0fdc",
 		"name": "Conformance Suite",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "4338127"
@@ -333,60 +333,6 @@
 										}
 									},
 									"response": []
-								},
-								{
-									"name": "identifiers:missing_scope:resolve:dids",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"exec": [
-													"pm.test(\"status code is 403\", function () {",
-													" pm.response.to.have.status(403);",
-													"});",
-													"",
-													"pm.test(\"response validates against schema\", function() {",
-													" const schemaString = pm.collectionVariables.get(\"responseSchema403\");",
-													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
-													"});",
-													""
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "prerequest",
-											"script": {
-												"exec": [
-													"// Obtain an access token without the required \"resolve:dids\" scope",
-													"utils(pm).getAccessToken('')",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "GET",
-										"header": [
-											{
-												"key": "Accept",
-												"value": "application/json",
-												"type": "text"
-											}
-										],
-										"url": {
-											"raw": "{{API_BASE_URL}}/identifiers/{{ORGANIZATION_DID_WEB}}",
-											"host": [
-												"{{API_BASE_URL}}"
-											],
-											"path": [
-												"identifiers",
-												"{{ORGANIZATION_DID_WEB}}"
-											]
-										}
-									},
-									"response": []
 								}
 							]
 						}
@@ -453,8 +399,8 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-							"// Obtain an access token with the required \"resolve:dids\" scope",
-							"utils(pm).getAccessToken('resolve:dids');",
+							"// Obtain an access token",
+							"utils(pm).getAccessToken();",
 							""
 						]
 					}
@@ -6576,84 +6522,6 @@
 										}
 									},
 									"response": []
-								},
-								{
-									"name": "credentials_issue:missing_scope:issue_credentials",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"exec": [
-													"pm.test(\"status code is 403\", function () {",
-													" pm.response.to.have.status(403);",
-													"});",
-													"",
-													"pm.test(\"response validates against schema\", function() {",
-													" const schemaString = pm.collectionVariables.get(\"responseSchema403\");",
-													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
-													"});",
-													""
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "prerequest",
-											"script": {
-												"exec": [
-													"// Obtain an access token without the required \"issue:credentials\" scope",
-													"utils(pm).getAccessToken('');",
-													"",
-													"// Request body must be serialized before sending over the wire.",
-													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
-													"    // noop",
-													"}));",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [
-												{
-													"key": "token",
-													"value": "{{currentAccessToken}}",
-													"type": "string"
-												}
-											]
-										},
-										"method": "POST",
-										"header": [
-											{
-												"key": "Accept",
-												"value": "application/json",
-												"type": "text"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{{requestBody}}",
-											"options": {
-												"raw": {
-													"language": "json"
-												}
-											}
-										},
-										"url": {
-											"raw": "{{API_BASE_URL}}/credentials/issue",
-											"host": [
-												"{{API_BASE_URL}}"
-											],
-											"path": [
-												"credentials",
-												"issue"
-											]
-										}
-									},
-									"response": []
 								}
 							],
 							"auth": {
@@ -7176,10 +7044,8 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-							"// Populate \"currentAccessToken\" with a bearer token that has the required",
-							"// \"issue:credentials\" scope.",
-							"",
-							"utils(pm).getAccessToken('issue:credentials');",
+							"// Obtain an access token",
+							"utils(pm).getAccessToken();",
 							"",
 							"// Some values are stored in variables so that they can be substituted",
 							"// into the request body and so that the response body can be tested to",
@@ -9441,77 +9307,6 @@
 										}
 									},
 									"response": []
-								},
-								{
-									"name": "credentials_status:missing_scope:update_credentials",
-									"event": [
-										{
-											"listen": "prerequest",
-											"script": {
-												"exec": [
-													"// Obtain an access token without the required \"update:credentials\" scope",
-													"utils(pm).getAccessToken('');",
-													"",
-													"// Request body must be serialized before sending over the wire.",
-													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
-													"    // noop",
-													"}));"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "test",
-											"script": {
-												"exec": [
-													"pm.test(\"status code is 403\", function () {",
-													" pm.response.to.have.status(403);",
-													"});",
-													"",
-													"pm.test(\"response validates against schema\", function() {",
-													" const schemaString = pm.collectionVariables.get(\"responseSchema403\");",
-													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
-													"});",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [
-												{
-													"key": "token",
-													"value": "{{currentAccessToken}}",
-													"type": "string"
-												}
-											]
-										},
-										"method": "POST",
-										"header": [],
-										"body": {
-											"mode": "raw",
-											"raw": "{{requestBody}}",
-											"options": {
-												"raw": {
-													"language": "json"
-												}
-											}
-										},
-										"url": {
-											"raw": "{{API_BASE_URL}}/credentials/status",
-											"host": [
-												"{{API_BASE_URL}}"
-											],
-											"path": [
-												"credentials",
-												"status"
-											]
-										}
-									},
-									"response": []
 								}
 							],
 							"auth": {
@@ -9557,10 +9352,8 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-							"// Populate \"currentAccessToken\" with a bearer token that has the required",
-							"// \"update:credentials\" scope.",
-							"",
-							"utils(pm).getAccessToken('update:credentials');",
+							"// Obtain an access token",
+							"utils(pm).getAccessToken();",
 							"",
 							"// Some values are stored in variables so that they can be substituted",
 							"// into the request body and so that the response body can be tested to",
@@ -14511,75 +14304,6 @@
 										}
 									},
 									"response": []
-								},
-								{
-									"name": "credentials_verify:missing_scope:verify_credentials",
-									"event": [
-										{
-											"listen": "prerequest",
-											"script": {
-												"exec": [
-													"// Obtain an access token without the required \"verify:credentials\" scope",
-													"utils(pm).getAccessToken('');",
-													"",
-													"// Request body must be serialized before sending over the wire.",
-													"pm.variables.set(\"requestBody\", JSON.stringify(pm.variables.get(\"valid_vc\")));"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "test",
-											"script": {
-												"exec": [
-													"pm.test(\"status code is 403\", function () {",
-													" pm.response.to.have.status(403);",
-													"});",
-													"",
-													"pm.test(\"response validates against schema\", function() {",
-													" const schemaString = pm.collectionVariables.get(\"responseSchema403\");",
-													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
-													"});",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [
-												{
-													"key": "token",
-													"value": "{{currentAccessToken}}",
-													"type": "string"
-												}
-											]
-										},
-										"method": "POST",
-										"header": [],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n    \"verifiableCredential\": {{requestBody}}\n}",
-											"options": {
-												"raw": {
-													"language": "json"
-												}
-											}
-										},
-										"url": {
-											"raw": "{{API_BASE_URL}}/credentials/verify",
-											"host": [
-												"{{API_BASE_URL}}"
-											],
-											"path": [
-												"credentials",
-												"verify"
-											]
-										}
-									},
-									"response": []
 								}
 							],
 							"auth": {
@@ -14830,8 +14554,8 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-							"// Obtain an access token with the required \"verify:credentials\" scope",
-							"utils(pm).getAccessToken('verify:credentials');",
+							"// Obtain an access token",
+							"utils(pm).getAccessToken();",
 							"",
 							"// Dummy VC issued for testing",
 							"pm.variables.set(\"valid_vc\", {",
@@ -14925,68 +14649,6 @@
 										}
 									},
 									"response": []
-								},
-								{
-									"name": "presentations:missing_scope:submit_presentations",
-									"event": [
-										{
-											"listen": "prerequest",
-											"script": {
-												"exec": [
-													"// Obtain an access token without the required \"submit:presentations\" scope",
-													"utils(pm).getAccessToken('');",
-													"",
-													"// Get multi-tenant aware presentations base URL from cached did:web document",
-													"const didDoc = pm.variables.get(\"currentDidWeb\");",
-													"const service = didDoc.service.find((s) => s.type.includes('TraceabilityAPI'));",
-													"pm.variables.set(\"presentations_base_url\", service.serviceEndpoint);",
-													""
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "test",
-											"script": {
-												"exec": [
-													"pm.test(\"status code is 403\", function () {",
-													" pm.response.to.have.status(403);",
-													"});",
-													"",
-													"pm.test(\"response validates against schema\", function() {",
-													" const schemaString = pm.collectionVariables.get(\"responseSchema403\");",
-													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
-													"});",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [
-												{
-													"key": "token",
-													"value": "{{currentAccessToken}}",
-													"type": "string"
-												}
-											]
-										},
-										"method": "POST",
-										"header": [],
-										"url": {
-											"raw": "{{presentations_base_url}}/presentations",
-											"host": [
-												"{{presentations_base_url}}"
-											],
-											"path": [
-												"presentations"
-											]
-										}
-									},
-									"response": []
 								}
 							],
 							"auth": {
@@ -15032,10 +14694,8 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-							"// Obtain an access token with the required \"submit:presentations\" scope.  This",
-							"// fires off an async sendRequest() that Postman will wait for before running",
-							"// any requests in the collection.",
-							"utils(pm).getAccessToken('submit:presentations');",
+							"// Obtain an access token",
+							"utils(pm).getAccessToken();",
 							"",
 							"// Presentations requires a multi-tenant aware presentation endpoint. This",
 							"// fires off an async sendRequest() that Postman will wait for before running",
@@ -15128,82 +14788,6 @@
 										}
 									},
 									"response": []
-								},
-								{
-									"name": "presentations_prove:missing_scope:prove_presentations",
-									"event": [
-										{
-											"listen": "prerequest",
-											"script": {
-												"exec": [
-													"// Obtain an access token without the required \"prove:presentations\" scope",
-													"utils(pm).getAccessToken('');",
-													"",
-													"// Get multi-tenant aware presentations base URL from cached did:web document",
-													"const didDoc = pm.variables.get(\"currentDidWeb\");",
-													"const service = didDoc.service.find((s) => s.type.includes('TraceabilityAPI'));",
-													"pm.variables.set(\"presentations_base_url\", service.serviceEndpoint);",
-													"",
-													"// Request body must be serialized before sending over the wire.",
-													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
-													"    // noop",
-													"}));"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "test",
-											"script": {
-												"exec": [
-													"pm.test(\"status code is 403\", function () {",
-													" pm.response.to.have.status(403);",
-													"});",
-													"",
-													"pm.test(\"response validates against schema\", function() {",
-													" const schemaString = pm.collectionVariables.get(\"responseSchema403\");",
-													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
-													"});",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [
-												{
-													"key": "token",
-													"value": "{{currentAccessToken}}",
-													"type": "string"
-												}
-											]
-										},
-										"method": "POST",
-										"header": [],
-										"body": {
-											"mode": "raw",
-											"raw": "{{requestBody}}",
-											"options": {
-												"raw": {
-													"language": "json"
-												}
-											}
-										},
-										"url": {
-											"raw": "{{presentations_base_url}}/presentations/prove",
-											"host": [
-												"{{presentations_base_url}}"
-											],
-											"path": [
-												"presentations",
-												"prove"
-											]
-										}
-									},
-									"response": []
 								}
 							],
 							"auth": {
@@ -15242,10 +14826,9 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-							"// Obtain an access token with the required \"prove:presentations\" scope.  This",
-							"// fires off an async sendRequest() that Postman will wait for before running",
-							"// any requests in the collection.",
-							"utils(pm).getAccessToken('prove:presentations');",
+							"// Obtain an access token",
+							"utils(pm).getAccessToken();",
+							"",
 							"",
 							"// Presentations requires a multi-tenant aware presentation endpoint. This",
 							"// fires off an async sendRequest() that Postman will wait for before running",
@@ -15355,82 +14938,6 @@
 										}
 									},
 									"response": []
-								},
-								{
-									"name": "presentations_verify:missing_scope:verify_presentations",
-									"event": [
-										{
-											"listen": "prerequest",
-											"script": {
-												"exec": [
-													"// Obtain an access token without the required \"verify:presentations\" scope",
-													"utils(pm).getAccessToken('');",
-													"",
-													"// Get multi-tenant aware presentations base URL from cached did:web document",
-													"const didDoc = pm.variables.get(\"currentDidWeb\");",
-													"const service = didDoc.service.find((s) => s.type.includes('TraceabilityAPI'));",
-													"pm.variables.set(\"presentations_base_url\", service.serviceEndpoint);",
-													"",
-													"// Request body must be serialized before sending over the wire.",
-													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
-													"    // noop",
-													"}));"
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "test",
-											"script": {
-												"exec": [
-													"pm.test(\"status code is 403\", function () {",
-													" pm.response.to.have.status(403);",
-													"});",
-													"",
-													"pm.test(\"response validates against schema\", function() {",
-													" const schemaString = pm.collectionVariables.get(\"responseSchema403\");",
-													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
-													"});",
-													""
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"auth": {
-											"type": "bearer",
-											"bearer": [
-												{
-													"key": "token",
-													"value": "{{currentAccessToken}}",
-													"type": "string"
-												}
-											]
-										},
-										"method": "POST",
-										"header": [],
-										"body": {
-											"mode": "raw",
-											"raw": "{{requestBody}}",
-											"options": {
-												"raw": {
-													"language": "json"
-												}
-											}
-										},
-										"url": {
-											"raw": "{{presentations_base_url}}/presentations/verify",
-											"host": [
-												"{{presentations_base_url}}"
-											],
-											"path": [
-												"presentations",
-												"verify"
-											]
-										}
-									},
-									"response": []
 								}
 							],
 							"auth": {
@@ -15469,10 +14976,9 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-							"// Obtain an access token with the required \"verify:presentations\" scope.  This",
-							"// fires off an async sendRequest() that Postman will wait for before running",
-							"// any requests in the collection.",
-							"utils(pm).getAccessToken('verify:presentations');",
+							"// Obtain an access token",
+							"utils(pm).getAccessToken();",
+							"",
 							"",
 							"// Presentations requires a multi-tenant aware presentation endpoint. This",
 							"// fires off an async sendRequest() that Postman will wait for before running",
@@ -15629,9 +15135,11 @@
 					"                pm.variables.set(\"currentDidWeb\", didWebCache[did]);",
 					"            });",
 					"        },",
-					"        getAccessToken: (scope) => {",
-					"            if (tokenCache[scope]) {",
-					"                pm.variables.set('currentAccessToken', tokenCache[scope]);",
+					"        getAccessToken: () => {",
+					"            // Historically, multiple tokens were keyed by scope.",
+					"            const cacheKey = \"default\";",
+					"            if (tokenCache[cacheKey]) {",
+					"                pm.variables.set('currentAccessToken', tokenCache[cacheKey]);",
 					"                return;",
 					"            }",
 					"            const accessTokenRequest = {",
@@ -15644,15 +15152,15 @@
 					"                        {key: \"client_secret\", value: pm.environment.get(\"CLIENT_SECRET\")},",
 					"                        {key: \"audience\", value: pm.environment.get(\"TOKEN_AUDIENCE\")},",
 					"                        {key: \"grant_type\", value: \"client_credentials\" },",
-					"                        {key: \"scope\", value: scope},",
+					"                        {key: \"scope\", value: pm.environment.get(\"CLIENT_SCOPE\")},",
 					"                    ],",
 					"                }",
 					"            };",
 					"            pm.sendRequest(accessTokenRequest, (err, res) => {",
 					"                pm.expect(err).to.be.null;",
-					"                tokenCache[scope] = res.json().access_token;",
+					"                tokenCache[cacheKey] = res.json().access_token;",
 					"                pm.globals.set(\"tokenCache\", JSON.stringify(tokenCache));",
-					"                pm.variables.set(\"currentAccessToken\", tokenCache[scope]);",
+					"                pm.variables.set(\"currentAccessToken\", tokenCache[cacheKey]);",
 					"            });",
 					"        },",
 					"    };",

--- a/tests/conformance_suite.postman_environment.json
+++ b/tests/conformance_suite.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "ee5f51a9-53ee-4321-95c3-90c06741c32f",
+	"id": "d7a28a8c-69bc-4df1-86f3-47376a3b7c68",
 	"name": "Traceability Conformance",
 	"values": [
 		{
@@ -18,6 +18,12 @@
 			"key": "CLIENT_SECRET",
 			"value": "<your OAuth2 client_secret goes here>",
 			"type": "secret",
+			"enabled": true
+		},
+		{
+			"key": "CLIENT_SCOPE",
+			"value": "<use if oidc provider requires you to list scopes>",
+			"type": "default",
 			"enabled": true
 		},
 		{
@@ -40,6 +46,6 @@
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2022-11-09T17:26:08.454Z",
-	"_postman_exported_using": "Postman/9.31.22"
+	"_postman_exported_at": "2023-05-23T13:56:55.252Z",
+	"_postman_exported_using": "Postman/9.31.29"
 }


### PR DESCRIPTION
This PR seeks to resolve issue #457 by relaxing the scope-related requirements for conformance via the following changes:

* Conformance testing no longer requires that OAuth2 providers grant ONLY those scopes requested
* Conformance testing no longer requires that specific scopes be present in order to pass testing
* Default behavior assumes that OAuth2 provider includes _all_ scopes granted to a client ID in the JWT token
* Override behavior allows implementations to provide a list of scopes that client should request via the `CLIENT_SCOPE` configuration variable.

A brief summary of code changes:
* All tests for `missing_scope` have been removed.
* Tests which require authentication no longer individually specify which scopes should be requested
* Sample environment configuration now includes `CLIENT_SCOPE` variable
* Library function `getAccessToken()` no longer accepts a `scope` argument and manages which scopes are requested based on `CLIENT_SCOPE` environment variable.

If we approve this PR, the following additional work will need to be done:
* Modify interoperability tests as needed
* Update documentation and respec as needed

Fixes #457
References #500
