### PR TITLE
refactor: remove inline CSS

### DIFF
--- a/reporting/assets/conformance.j2
+++ b/reporting/assets/conformance.j2
@@ -59,38 +59,34 @@
             color: #f3f3f3 !important;
         }
 
-        .card {
-            padding: 0;
-            width: 20rem;
-            margin-right: 8px;
-            margin-bottom: 8px;
+        .detail-table thead th {
+            padding: 6px;
+            text-align: center;
+            max-width: 220px;
+            background-color: rgb(30, 30, 30);
+            color: white;
+            border-bottom: none;
+            border-top: 1px solid rgb(30, 30, 30);
+            border-left: 1px solid rgb(30, 30, 30);
+            border-right: 1px solid rgb(30, 30, 30);
+            overflow-x: hidden;
+            white-space: nowrap;
         }
 
-        .card-text {
-            color: #999999;
-            margin-bottom: 5.5px;
-            font-size: 14px;
-            display: block;
+        .detail-table tbody td {
+            padding: 6px;
+            text-align: left;
+            max-width: 220px;
+            color: white;
+            border-width: 1px;
+            border-style: solid;
+            border-color: rgb(30, 30, 30);
+            overflow-x: hidden;
+            white-space: nowrap;
         }
 
-        .card-title {
-            font-weight: bold;
-            font-size: 30px;
-            margin-top: 0;
-            margin-bottom: 0px;
-        }
-
-        .cell-markdown {
-            padding: 4px;
-        }
-
-        .cell-markdown p {
-            margin-bottom: 0;
-        }
-
-        .dash-table-container .dash-spreadsheet-container .dash-spreadsheet-inner input:not([type=radio]):not([type=checkbox]) {
-            color: #f3f3f3 !important;
-        }
+        .detail-table tbody tr:nth-child(odd) {background: rgb(39, 43, 48)}
+        .detail-table tbody tr:nth-child(even) {background: rgb(49, 53, 58)}
     </style>
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     <link rel="stylesheet"

--- a/reporting/assets/interoperability.j2
+++ b/reporting/assets/interoperability.j2
@@ -47,50 +47,38 @@
             margin-bottom: 0px;
         }
 
-        .cell-markdown {
-            padding: 4px;
-        }
-
-        .cell-markdown p {
-            margin-bottom: 0;
-        }
-
         .dash-table-container .dash-spreadsheet-container .dash-spreadsheet-inner input:not([type=radio]):not([type=checkbox]) {
             color: #f3f3f3 !important;
         }
 
-        .card {
-            padding: 0;
-            width: 20rem;
-            margin-right: 8px;
-            margin-bottom: 8px;
+        .detail-table thead th {
+            padding: 6px;
+            text-align: center;
+            max-width: 220px;
+            background-color: rgb(30, 30, 30);
+            color: white;
+            border-bottom: none;
+            border-top: 1px solid rgb(30, 30, 30);
+            border-left: 1px solid rgb(30, 30, 30);
+            border-right: 1px solid rgb(30, 30, 30);
+            overflow-x: hidden;
+            white-space: nowrap;
         }
 
-        .card-text {
-            color: #999999;
-            margin-bottom: 5.5px;
-            font-size: 14px;
-            display: block;
+        .detail-table tbody td {
+            padding: 6px;
+            text-align: left;
+            max-width: 220px;
+            color: white;
+            border-width: 1px;
+            border-style: solid;
+            border-color: rgb(30, 30, 30);
+            overflow-x: hidden;
+            white-space: nowrap;
         }
 
-        .card-title {
-            font-weight: bold;
-            font-size: 30px;
-            margin-top: 0;
-            margin-bottom: 0px;
-        }
-
-        .cell-markdown {
-            padding: 4px;
-        }
-
-        .cell-markdown p {
-            margin-bottom: 0;
-        }
-
-        .dash-table-container .dash-spreadsheet-container .dash-spreadsheet-inner input:not([type=radio]):not([type=checkbox]) {
-            color: #f3f3f3 !important;
-        }
+        .detail-table tbody tr:nth-child(odd) {background: rgb(39, 43, 48)}
+        .detail-table tbody tr:nth-child(even) {background: rgb(49, 53, 58)}
     </style>
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     <link rel="stylesheet"

--- a/reporting/postman_reporter/report_static.py
+++ b/reporting/postman_reporter/report_static.py
@@ -57,54 +57,14 @@ def renderTable(df):
               <div class="dt-table-container__row dt-table-container__row-1">
                 <div class="cell cell-1-0"></div>
                 <div class="cell cell-1-1 dash-fixed-content" style="margin-left: -0.5px">
-                  <table class="cell-table" tabindex="-1">
-                    <tbody>
+                  <table class="detail-table cell-table" tabindex="-1">
+                    <thead>
                       <tr>
-                        {% for cell in columns -%}
-                        <th class="dash-header column-0"
-                          style="
-                            padding: 2px;
-                            text-align: center;
-                            max-width: 220px;
-                            background-color: rgb(30, 30, 30);
-                            color: white;
-                            border-bottom: none;
-                            border-top: 1px solid rgb(30, 30, 30);
-                            border-left: 1px solid rgb(30, 30, 30);
-                            border-right: 1px solid rgb(30, 30, 30);
-                            overflow-x: hidden;
-                          "
-                        >
-                          <div>
-                            <span class="column-header-name" style="white-space:nowrap;">{{cell}}</span>
-                          </div>
-                        </th>
-                        {% endfor -%}
+                        {% for cell in columns -%}<th>{{cell}}</th>{% endfor -%}
                       </tr>
-                      {%for row in rows -%}
-                      <tr style="background-color: {{ loop.cycle('rgb(39, 43, 48)', 'rgb(49, 53, 58)') }};">
-                        {% for cell in row -%}
-                        <td
-                          tabindex="-1"
-                          class="dash-cell column-0"
-                          style="
-                            padding: 2px;
-                            text-align: left;
-                            max-width: 220px;
-                            color: white;
-                            border-width: 1px;
-                            border-style: solid;
-                            border-color: rgb(30, 30, 30);
-                            overflow-x: hidden;
-                          "
-                        >
-                          <div class="unfocused dash-cell-value cell-markdown">
-                            <p style="white-space:nowrap;">{{cell}}</p>
-                          </div>
-                        </td>
-                        {% endfor -%}
-                      </tr>
-                      {% endfor -%}
+                    </thead>
+                    <tbody>
+                      {%for row in rows -%}<tr>{% for cell in row -%}<td>{{cell}}</td>{% endfor -%}</tr>{% endfor -%}
                     </tbody>
                   </table>
                 </div>

--- a/reporting/postman_reporter/reporter_util.py
+++ b/reporting/postman_reporter/reporter_util.py
@@ -1,12 +1,12 @@
 # %% imports
 import glob
-
 import inspect
 import pickle
-
 from typing import List
-from tqdm import tqdm
+
 from postman_reporter.report_config import *
+from tqdm import tqdm
+
 
 # %% methods
 def get_var_name(var):
@@ -48,7 +48,7 @@ def get_html_base():
                     width: 100%;
                     max-width: 100%;
                     min-width: 100%;
-                    min-height: 100%;                    
+                    min-height: 100%;
                 }
                 #page-content {
                     margin-left: 1rem !important;
@@ -79,12 +79,42 @@ def get_html_base():
                     padding: 4px;
                 }
                 .cell-markdown p  {
-                    margin-bottom: 0; 
+                    margin-bottom: 0;
                 }
 
                 .dash-table-container .dash-spreadsheet-container .dash-spreadsheet-inner input:not([type=radio]):not([type=checkbox]){
                     color: #f3f3f3!important;
                 }
+
+                .detail-table thead th {
+                    padding: 6px;
+                    text-align: center;
+                    max-width: 220px;
+                    background-color: rgb(30, 30, 30);
+                    color: white;
+                    border-bottom: none;
+                    border-top: 1px solid rgb(30, 30, 30);
+                    border-left: 1px solid rgb(30, 30, 30);
+                    border-right: 1px solid rgb(30, 30, 30);
+                    overflow-x: hidden;
+                    white-space:nowrap;
+                }
+
+                .detail-table tbody td {
+                    padding: 6px;
+                    text-align: left;
+                    max-width: 220px;
+                    color: white;
+                    border-width: 1px;
+                    border-style: solid;
+                    border-color: rgb(30, 30, 30);
+                    overflow-x: hidden;
+                    padding: 4px;
+                    white-space: nowrap;
+                }
+
+                .detail-table tbody tr:nth-child(odd) {background: rgb(39, 43, 48)}
+                .detail-table tbody tr:nth-child(even) {background: rgb(49, 53, 58)}
             </style>
             {%css%}
         </head>


### PR DESCRIPTION
This PR moves inline CSS into the existing `style` block in the HTML header for generated test reports. This change results in a size decrease for the two generated HTML files from about 21MB to about 1MB nightly.

Fixes #547 