### PR TITLE
Bring Credentials Revocation Tutorial in line with StatusList2021 spec

### DIFF
--- a/docs/tutorials/credentials-revocation/credentials-revocation.postman_collection.json
+++ b/docs/tutorials/credentials-revocation/credentials-revocation.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "97bd6bb0-fb39-4bd6-94ee-dfc43b5f2c51",
+		"_postman_id": "02287f5e-2395-44ef-8548-7e5214382fe2",
 		"name": "Credentials Revocation Tutorial",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "15641111"
+		"_exporter_id": "3967759"
 	},
 	"item": [
 		{
@@ -406,7 +406,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"credentialId\": \"{{verifiable_credential_id}}\",\n    \"credentialStatus\": [\n        {\n            \"type\": \"RevocationList2020Status\",\n            \"status\": \"1\"\n        }\n    ]\n}",
+					"raw": "{\n    \"credentialId\": \"{{verifiable_credential_id}}\",\n    \"credentialStatus\": [\n        {\n            \"type\": \"StatusList2021Entry\",\n            \"statusPurpose\": \"revocation\",\n            \"status\": \"1\"\n        }\n    ]\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -455,16 +455,10 @@
 							"    pm.response.to.have.status(200);",
 							"});",
 							"",
-							"// Checks should have errors",
-							"//pm.test(\"Checks should have credentialStatus errors\", function() {",
-							"//    const { errors } = pm.response.json();",
-							"//    pm.expect(errors).to.include(\"credentialStatus\");",
-							"//});",
-							"",
 							"// Confirm error",
-							"pm.test(\"Checks should have credentialStatus errors\", function() {",
-							"    let obj = pm.response.json().verifications.find(e => e.title === \"Revocation\");",
-							"    pm.expect(obj.status).to.eql(\"bad\");",
+							"pm.test(\"Response 'verified' property should be false\", function() {",
+							"    const { verified } = pm.response.json()",
+							"    pm.expect(verified).to.be.false;",
 							"});",
 							"",
 							"",


### PR DESCRIPTION
This PR updates the Credentials Revocation Tutorial tests to be compatible with the [Status List 2021 spec](https://www.w3.org/TR/vc-status-list/), as discussed in https://github.com/w3c-ccg/traceability-interop/pull/555 and mandated by the [current Trace Interop spec](https://w3c-ccg.github.io/traceability-interop/draft/#data-integrity-proof-suites).

For implementations which do not support Status List 2021, these changes will cause tests to fail for the `Revoke Credential` and `Verify Revocation` tests within the `Credentials Revocation Tutorial` Postman collection.
