### PR TITLE
Update conformance tests to use status list 2021

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "e9c7f21a-ef69-4217-8f40-0424834c0fdc",
+		"_postman_id": "4bd78d4a-8f35-432a-a4e9-9e5a47c7c93c",
 		"name": "Conformance Suite",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "4338127"
+		"_exporter_id": "3967759"
 	},
 	"item": [
 		{
@@ -5698,7 +5698,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // options.credentialStatus must be object, not array",
-													"    req.options.credentialStatus = [\"RevocationList2020Status\"];",
+													"    req.options.credentialStatus = [\"StatusList2021Entry\"];",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -5958,7 +5958,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // options.credentialStatus must be object, not string",
-													"    req.options.credentialStatus = \"RevocationList2020Status\";",
+													"    req.options.credentialStatus = \"StatusList2021Entry\";",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -6088,7 +6088,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // options.credentialStatus.type must be string, not array",
-													"    req.options.credentialStatus = {\"type\": [\"RevocationList2020Status\"]};",
+													"    req.options.credentialStatus = {\"type\": [\"StatusList2021Entry\"]};",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -6966,7 +6966,7 @@
 										"exec": [
 											"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 											"    // options.credentialStatus can be an optional object",
-											"    req.options.credentialStatus = {\"type\": \"RevocationList2020Status\"};",
+											"    req.options.credentialStatus = {\"type\": \"StatusList2021Entry\"};",
 											"}));",
 											""
 										],
@@ -7791,7 +7791,8 @@
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus must be array, not object",
 													"    req.credentialstatus = {",
-													"        \"type\": \"RevocationList2020Status\",",
+													"        \"type\": \"StatusList2021Entry\",",
+													"        \"statusPurpose\": \"revocation\",",
 													"        \"status\": \"0\"",
 													"    };",
 													"}));"
@@ -7858,7 +7859,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus must be array, not string",
-													"    req.credentialstatus = \"RevocationList2020Status\";",
+													"    req.credentialstatus = \"StatusList2021Entry\";",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -7925,11 +7926,13 @@
 													"    // credentialStatus can only have zero or one elements.",
 													"    req.credentialstatus = [",
 													"        {",
-													"            \"type\": \"RevocationList2020Status\",",
+													"            \"type\": \"StatusList2021Entry\",",
+													"            \"statusPurpose\": \"revocation\",",
 													"            \"status\": \"0\",",
 													"        },",
 													"        {",
-													"            \"type\": \"RevocationList2020Status\",",
+													"            \"type\": \"StatusList2021Entry\",",
+													"            \"statusPurpose\": \"revocation\",",
 													"            \"status\": \"1\",",
 													"        }",
 													"    ];",
@@ -8257,7 +8260,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus elements must be object, not string",
-													"    req.credentialstatus = [\"RevocationList2020Status\"];",
+													"    req.credentialstatus = [\"StatusList2021Entry\"];",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -8390,7 +8393,8 @@
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item type must be string, not array",
 													"    req.credentialstatus = [{",
-													"        \"type\": [\"RevocationList2020Status\"],",
+													"        \"type\": [\"StatusList2021Entry\"],",
+													"        \"statusPurpose\": \"revocation\",",
 													"        \"status\": \"0\",",
 													"    }];",
 													"}));"
@@ -8798,7 +8802,8 @@
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status is a required property",
 													"    req.credentialstatus = [{",
-													"        \"type\": \"RevocationList2020Status\",",
+													"        \"type\": \"StatusList2021Entry\",",
+													"        \"purpose\": \"revocation\",",
 													"    }];",
 													"}));"
 												],
@@ -8865,7 +8870,8 @@
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not array",
 													"    req.credentialstatus = [{",
-													"        \"type\": \"RevocationList2020Status\",",
+													"        \"type\": \"StatusList2021Entry\",",
+													"        \"purpose\": \"revocation\",",
 													"        \"status\": [\"0\"],",
 													"    }];",
 													"}));"
@@ -8933,7 +8939,8 @@
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not boolean",
 													"    req.credentialstatus = [{",
-													"        \"type\": \"RevocationList2020Status\",",
+													"        \"type\": \"StatusList2021Entry\",",
+													"        \"purpose\": \"revocation\",",
 													"        \"status\": false,",
 													"    }];",
 													"}));"
@@ -9001,7 +9008,8 @@
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not integer",
 													"    req.credentialstatus = [{",
-													"        \"type\": \"RevocationList2020Status\",",
+													"        \"type\": \"StatusList2021Entry\",",
+													"        \"purpose\": \"revocation\",",
 													"        \"status\": 1,",
 													"    }];",
 													"}));"
@@ -9069,7 +9077,8 @@
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not null",
 													"    req.credentialstatus = [{",
-													"        \"type\": \"RevocationList2020Status\",",
+													"        \"type\": \"StatusList2021Entry\",",
+													"        \"purpose\": \"revocation\",",
 													"        \"status\": null,",
 													"    }];",
 													"}));"
@@ -9137,76 +9146,9 @@
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not object",
 													"    req.credentialstatus = [{",
-													"        \"type\": \"RevocationList2020Status\",",
+													"        \"type\": \"StatusList2021Entry\",",
+													"        \"purpose\": \"revocation\",",
 													"        \"status\": {},",
-													"    }];",
-													"}));"
-												],
-												"type": "text/javascript"
-											}
-										}
-									],
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "Accept",
-												"value": "application/json",
-												"type": "text"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{{requestBody}}",
-											"options": {
-												"raw": {
-													"language": "json"
-												}
-											}
-										},
-										"url": {
-											"raw": "{{API_BASE_URL}}/credentials/status",
-											"host": [
-												"{{API_BASE_URL}}"
-											],
-											"path": [
-												"credentials",
-												"status"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "credentials_status:credentialStatus:item:status:invalid",
-									"event": [
-										{
-											"listen": "test",
-											"script": {
-												"exec": [
-													"pm.test(\"status code is 400\", function () {",
-													" pm.response.to.have.status(400);",
-													"});",
-													"",
-													"pm.test(\"response validates against schema\", function() {",
-													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
-													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
-													"});",
-													"",
-													""
-												],
-												"type": "text/javascript"
-											}
-										},
-										{
-											"listen": "prerequest",
-											"script": {
-												"exec": [
-													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
-													"    // credentialStatus item status must be a valid value",
-													"    req.credentialstatus = [{",
-													"        \"type\": \"RevocationList2020Status\",",
-													"        \"status\": \"invalid value\",",
 													"    }];",
 													"}));"
 												],

--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -7791,6 +7791,2296 @@
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus must be array, not object",
 													"    req.credentialstatus = {",
+													"        \"type\": \"RevocationList2020Status\",",
+													"        \"status\": \"0\"",
+													"    };",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:string",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus must be array, not string",
+													"    req.credentialstatus = \"RevocationList2020Status\";",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:too_long",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus can only have zero or one elements.",
+													"    req.credentialstatus = [",
+													"        {",
+													"            \"type\": \"RevocationList2020Status\",",
+													"            \"status\": \"0\",",
+													"        },",
+													"        {",
+													"            \"type\": \"RevocationList2020Status\",",
+													"            \"status\": \"1\",",
+													"        }",
+													"    ];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:array",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus elements must be object, not array",
+													"    req.credentialstatus = [[]];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:boolean",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus elements must be object, not boolean",
+													"    req.credentialstatus = [false];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:integer",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus elements must be object, not integer",
+													"    req.credentialstatus = [42];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:null",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus elements must be object, not null",
+													"    req.credentialstatus = [null];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:string",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus elements must be object, not string",
+													"    req.credentialstatus = [\"RevocationList2020Status\"];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:type:missing",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item type is a required property",
+													"    req.credentialstatus = [{",
+													"        \"status\": \"0\",",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:type:array",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item type must be string, not array",
+													"    req.credentialstatus = [{",
+													"        \"type\": [\"RevocationList2020Status\"],",
+													"        \"status\": \"0\",",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:type:boolean",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item type must be string, not boolean",
+													"    req.credentialstatus = [{",
+													"        \"type\": false,",
+													"        \"status\": \"0\",",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:type:integer",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item type must be string, not integer",
+													"    req.credentialstatus = [{",
+													"        \"type\": 42,",
+													"        \"status\": \"0\",",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:type:null",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item type must be string, not null",
+													"    req.credentialstatus = [{",
+													"        \"type\": null,",
+													"        \"status\": \"0\",",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:type:object",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item type must be string, not object",
+													"    req.credentialstatus = [{",
+													"        \"type\": {},",
+													"        \"status\": \"0\",",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:type:invalid",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item type must be a valid value",
+													"    req.credentialstatus = [{",
+													"        \"type\": \"invalid value\",",
+													"        \"status\": \"0\",",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:status:missing",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item status is a required property",
+													"    req.credentialstatus = [{",
+													"        \"type\": \"RevocationList2020Status\",",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:status:array",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item status must be string, not array",
+													"    req.credentialstatus = [{",
+													"        \"type\": \"RevocationList2020Status\",",
+													"        \"status\": [\"0\"],",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:status:boolean",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item status must be string, not boolean",
+													"    req.credentialstatus = [{",
+													"        \"type\": \"RevocationList2020Status\",",
+													"        \"status\": false,",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:status:integer",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item status must be string, not integer",
+													"    req.credentialstatus = [{",
+													"        \"type\": \"RevocationList2020Status\",",
+													"        \"status\": 1,",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:status:null",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item status must be string, not null",
+													"    req.credentialstatus = [{",
+													"        \"type\": \"RevocationList2020Status\",",
+													"        \"status\": null,",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:status:object",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item status must be string, not object",
+													"    req.credentialstatus = [{",
+													"        \"type\": \"RevocationList2020Status\",",
+													"        \"status\": {},",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:status:invalid",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item status must be a valid value",
+													"    req.credentialstatus = [{",
+													"        \"type\": \"RevocationList2020Status\",",
+													"        \"status\": \"invalid value\",",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Bad Auth",
+							"item": [
+								{
+									"name": "credentials_status:missing_auth",
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"// Request body must be serialized before sending over the wire.",
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // noop",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 401\", function () {",
+													" pm.response.to.have.status(401);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema401\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"auth": {
+								"type": "noauth"
+							},
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								}
+							]
+						}
+					]
+				}
+			],
+			"auth": {
+				"type": "bearer",
+				"bearer": [
+					{
+						"key": "token",
+						"value": "{{currentAccessToken}}",
+						"type": "string"
+					}
+				]
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"// Obtain an access token",
+							"utils(pm).getAccessToken();",
+							"",
+							"// Some values are stored in variables so that they can be substituted",
+							"// into the request body and so that the response body can be tested to",
+							"// ensure it contains the same value.",
+							"",
+							"pm.variables.set(\"credentialId\", \"urn:uuid:{{$randomUUID}}\")",
+							"",
+							"// Minimal request body should represent the minimum set of data required",
+							"// to issue a valid credential. This should exclude all optional items, and",
+							"// should contain the first alternate version of any 'oneOf' elements",
+							"// defined in the OpenAPI schema.",
+							"//",
+							"// Tests will use this minimal request body as a starting point and will",
+							"// mutate it as needed in pre-request scripts, e.g., to run tests using",
+							"// alternate or optional elements.",
+							"",
+							"pm.variables.set(\"minimalRequestBody\", {",
+							"    \"credentialId\": pm.variables.get(\"credentialId\"),",
+							"    \"credentialStatus\": [],",
+							"});",
+							"",
+							"mutateRequestBody = (mutationFunction) => {",
+							"    const req = pm.variables.get(\"minimalRequestBody\");",
+							"    mutationFunction(req);",
+							"    return JSON.stringify(req);",
+							"};"
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Credentials - Update Status (StatusList2021)",
+			"item": [
+				{
+					"name": "Negative Testing",
+					"item": [
+						{
+							"name": "Bad Request",
+							"item": [
+								{
+									"name": "credentials_status:credentialId:missing",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialId is a required property",
+													"    delete req.credentialId;",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialId:array",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialId must be string, not array",
+													"    req.credentialId = [pm.variables.get(\"credentialId\")];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialId:boolean",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialId must be string, not boolean",
+													"    req.credentialId = false;",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialId:integer",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialId must be string, not integer",
+													"    req.credentialId = 42;",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialId:null",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialId must be string, not null",
+													"    req.credentialId = null;",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialId:object",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialId must be string, not object",
+													"    req.credentialId = {};",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:missing",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus is a required property",
+													"    delete req.credentialStatus;",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:boolean",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus must be array, not boolean",
+													"    req.credentialstatus = false;",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:integer",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus must be array, not integer",
+													"    req.credentialstatus = 42;",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:null",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus must be array, not null",
+													"    req.credentialstatus = null;",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:object",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus must be array, not object",
+													"    req.credentialstatus = {",
 													"        \"type\": \"StatusList2021Entry\",",
 													"        \"statusPurpose\": \"revocation\",",
 													"        \"status\": \"0\"",
@@ -9149,6 +11439,419 @@
 													"        \"type\": \"StatusList2021Entry\",",
 													"        \"purpose\": \"revocation\",",
 													"        \"status\": {},",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:purpose:missing",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item status is a required property",
+													"    req.credentialstatus = [{",
+													"        \"type\": \"StatusList2021Entry\",",
+													"        \"status\": \"1\",",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:purpose:array",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item status must be string, not array",
+													"    req.credentialstatus = [{",
+													"        \"type\": \"StatusList2021Entry\",",
+													"        \"purpose\": [\"revocation\"],",
+													"        \"status\": \"1\",",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:purpose:boolean",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item status must be string, not boolean",
+													"    req.credentialstatus = [{",
+													"        \"type\": \"StatusList2021Entry\",",
+													"        \"purpose\": false,",
+													"        \"status\": \"1\",",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:purpose:integer",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item status must be string, not integer",
+													"    req.credentialstatus = [{",
+													"        \"type\": \"StatusList2021Entry\",",
+													"        \"purpose\": 42,",
+													"        \"status\": \"1\",",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:purpose:null",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item status must be string, not null",
+													"    req.credentialstatus = [{",
+													"        \"type\": \"StatusList2021Entry\",",
+													"        \"purpose\": null,",
+													"        \"status\": \"1\",",
+													"    }];",
+													"}));"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/status",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"status"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "credentials_status:credentialStatus:item:purpose:object",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // credentialStatus item status must be string, not object",
+													"    req.credentialstatus = [{",
+													"        \"type\": \"StatusList2021Entry\",",
+													"        \"purpose\": {},",
+													"        \"status\": \"1\",",
 													"    }];",
 													"}));"
 												],


### PR DESCRIPTION
This PR updates the traceability conformance tests to be compatible with the [Status List 2021 spec](https://www.w3.org/TR/vc-status-list/), as discussed in https://github.com/w3c-ccg/traceability-interop/pull/555 and mandated by the [current Trace Interop spec](https://w3c-ccg.github.io/traceability-interop/draft/#data-integrity-proof-suites).

For implementations which do not support Status List 2021, these changes will cause some tests to fail within the `Credentials - Create` and `Credentials - Update Status` Postman collections.
