### PR TITLE
removes requirement of messages to be a specific enum

### DIFF
--- a/docs/openapi/responses/BadRequest.yml
+++ b/docs/openapi/responses/BadRequest.yml
@@ -6,5 +6,4 @@ content:
         - $ref: '../schemas/Error.yml'
         - type: object
           properties:
-            message:
-              enum: ["Bad Request: Your request body does not conform to the required schema"]
+            message

--- a/docs/openapi/responses/BadRequest.yml
+++ b/docs/openapi/responses/BadRequest.yml
@@ -2,4 +2,4 @@ description: Bad Request
 content:
   application/json:
     schema:
-      - $ref: '../schemas/Error.yml'
+      $ref: '../schemas/Error.yml'

--- a/docs/openapi/responses/BadRequest.yml
+++ b/docs/openapi/responses/BadRequest.yml
@@ -2,8 +2,4 @@ description: Bad Request
 content:
   application/json:
     schema:
-      allOf:
-        - $ref: '../schemas/Error.yml'
-        - type: object
-          properties:
-            message
+      - $ref: '../schemas/Error.yml'

--- a/docs/openapi/responses/ErrInvalidDID.yml
+++ b/docs/openapi/responses/ErrInvalidDID.yml
@@ -5,5 +5,4 @@ allOf:
   - $ref: '../schemas/Error.yml'
   - type: object
     properties:
-      message:
-        enum: ['Bad Request: Invalid DID']
+      message

--- a/docs/openapi/responses/ErrInvalidDID.yml
+++ b/docs/openapi/responses/ErrInvalidDID.yml
@@ -1,8 +1,4 @@
 description: |
   ErrInvalidDID is returned when the request path contains an invalid DID
   parameter.
-allOf:
-  - $ref: '../schemas/Error.yml'
-  - type: object
-    properties:
-      message
+$ref: '../schemas/Error.yml'

--- a/docs/openapi/responses/ErrUnknownIssuer.yml
+++ b/docs/openapi/responses/ErrUnknownIssuer.yml
@@ -6,5 +6,4 @@ allOf:
   - $ref: '../schemas/Error.yml'
   - type: object
     properties:
-      message:
-        enum: ['Unknown Issuer: Unable to issue credentials for specified issuer']
+      message

--- a/docs/openapi/responses/ErrUnknownIssuer.yml
+++ b/docs/openapi/responses/ErrUnknownIssuer.yml
@@ -2,8 +2,4 @@ description: |
   ErrUnknownIssuer is returned when the implementation does not have private
   key material for the requested `issuer`, and is therefore unable to issue
   the requested credential.
-allOf:
-  - $ref: '../schemas/Error.yml'
-  - type: object
-    properties:
-      message
+$ref: '../schemas/Error.yml'

--- a/docs/openapi/responses/NotFound.yml
+++ b/docs/openapi/responses/NotFound.yml
@@ -6,5 +6,4 @@ content:
         - $ref: '../schemas/Error.yml'
         - type: object
           properties:
-            message:
-              enum: ["Not Found: The requested resource could not be found"]
+            message

--- a/docs/openapi/responses/NotFound.yml
+++ b/docs/openapi/responses/NotFound.yml
@@ -2,8 +2,4 @@ description: Not Found
 content:
   application/json:
     schema:
-      allOf:
-        - $ref: '../schemas/Error.yml'
-        - type: object
-          properties:
-            message
+      - $ref: '../schemas/Error.yml'

--- a/docs/openapi/responses/NotFound.yml
+++ b/docs/openapi/responses/NotFound.yml
@@ -2,4 +2,4 @@ description: Not Found
 content:
   application/json:
     schema:
-      - $ref: '../schemas/Error.yml'
+      $ref: '../schemas/Error.yml'

--- a/docs/openapi/responses/Unauthenticated.yml
+++ b/docs/openapi/responses/Unauthenticated.yml
@@ -2,8 +2,4 @@ description: Unauthorized
 content:
   application/json:
     schema:
-      allOf:
-        - $ref: '../schemas/Error.yml'
-        - type: object
-          properties:
-            message
+      - $ref: '../schemas/Error.yml'

--- a/docs/openapi/responses/Unauthenticated.yml
+++ b/docs/openapi/responses/Unauthenticated.yml
@@ -2,4 +2,4 @@ description: Unauthorized
 content:
   application/json:
     schema:
-      - $ref: '../schemas/Error.yml'
+      $ref: '../schemas/Error.yml'

--- a/docs/openapi/responses/Unauthenticated.yml
+++ b/docs/openapi/responses/Unauthenticated.yml
@@ -6,5 +6,4 @@ content:
         - $ref: '../schemas/Error.yml'
         - type: object
           properties:
-            message:
-              enum: ["Unauthorized: This endpoint requires an OAuth2 bearer token"]
+            message

--- a/docs/openapi/responses/Unauthorized.yml
+++ b/docs/openapi/responses/Unauthorized.yml
@@ -2,4 +2,4 @@ description: Forbidden
 content:
   application/json:
     schema:
-      - $ref: '../schemas/Error.yml'
+      $ref: '../schemas/Error.yml'

--- a/docs/openapi/responses/Unauthorized.yml
+++ b/docs/openapi/responses/Unauthorized.yml
@@ -2,8 +2,4 @@ description: Forbidden
 content:
   application/json:
     schema:
-      allOf:
-        - $ref: '../schemas/Error.yml'
-        - type: object
-          properties:
-            message
+      - $ref: '../schemas/Error.yml'

--- a/docs/openapi/responses/Unauthorized.yml
+++ b/docs/openapi/responses/Unauthorized.yml
@@ -6,5 +6,4 @@ content:
         - $ref: '../schemas/Error.yml'
         - type: object
           properties:
-            message:
-              enum: ["Forbidden: OAuth2 bearer token does not have the required scope"]
+            message

--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -17831,22 +17831,22 @@
 		},
 		{
 			"key": "responseSchema400",
-			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":\"message\"}]}",
+			"value": "[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}]",
 			"type": "string"
 		},
 		{
 			"key": "responseSchema401",
-			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":\"message\"}]}",
+			"value": "[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}]",
 			"type": "string"
 		},
 		{
 			"key": "responseSchema403",
-			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":\"message\"}]}",
+			"value": "[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}]",
 			"type": "string"
 		},
 		{
 			"key": "responseSchema404",
-			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":\"message\"}]}",
+			"value": "[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}]",
 			"type": "string"
 		},
 		{
@@ -17861,7 +17861,7 @@
 		},
 		{
 			"key": "responseSchema400Identifiers",
-			"value": "{\"description\":\"ErrInvalidDID is returned when the request path contains an invalid DID\\nparameter.\\n\",\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":\"message\"}]}",
+			"value": "{\"description\":\"ErrInvalidDID is returned when the request path contains an invalid DID\\nparameter.\\n\",\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}",
 			"type": "string"
 		},
 		{
@@ -17876,7 +17876,7 @@
 		},
 		{
 			"key": "responseSchema422CredentialsIssue",
-			"value": "{\"description\":\"ErrUnknownIssuer is returned when the implementation does not have private\\nkey material for the requested `issuer`, and is therefore unable to issue\\nthe requested credential.\\n\",\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":\"message\"}]}",
+			"value": "{\"description\":\"ErrUnknownIssuer is returned when the implementation does not have private\\nkey material for the requested `issuer`, and is therefore unable to issue\\nthe requested credential.\\n\",\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}",
 			"type": "string"
 		}
 	]

--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -17831,22 +17831,22 @@
 		},
 		{
 			"key": "responseSchema400",
-			"value": "[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}]",
+			"value": "{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}",
 			"type": "string"
 		},
 		{
 			"key": "responseSchema401",
-			"value": "[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}]",
+			"value": "{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}",
 			"type": "string"
 		},
 		{
 			"key": "responseSchema403",
-			"value": "[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}]",
+			"value": "{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}",
 			"type": "string"
 		},
 		{
 			"key": "responseSchema404",
-			"value": "[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}]",
+			"value": "{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}}",
 			"type": "string"
 		},
 		{

--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -17831,22 +17831,22 @@
 		},
 		{
 			"key": "responseSchema400",
-			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"message\":{\"enum\":[\"Bad Request: Your request body does not conform to the required schema\"]}}}]}",
+			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":\"message\"}]}",
 			"type": "string"
 		},
 		{
 			"key": "responseSchema401",
-			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"message\":{\"enum\":[\"Unauthorized: This endpoint requires an OAuth2 bearer token\"]}}}]}",
+			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":\"message\"}]}",
 			"type": "string"
 		},
 		{
 			"key": "responseSchema403",
-			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"message\":{\"enum\":[\"Forbidden: OAuth2 bearer token does not have the required scope\"]}}}]}",
+			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":\"message\"}]}",
 			"type": "string"
 		},
 		{
 			"key": "responseSchema404",
-			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"message\":{\"enum\":[\"Not Found: The requested resource could not be found\"]}}}]}",
+			"value": "{\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":\"message\"}]}",
 			"type": "string"
 		},
 		{
@@ -17861,7 +17861,7 @@
 		},
 		{
 			"key": "responseSchema400Identifiers",
-			"value": "{\"description\":\"ErrInvalidDID is returned when the request path contains an invalid DID\\nparameter.\\n\",\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"message\":{\"enum\":[\"Bad Request: Invalid DID\"]}}}]}",
+			"value": "{\"description\":\"ErrInvalidDID is returned when the request path contains an invalid DID\\nparameter.\\n\",\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":\"message\"}]}",
 			"type": "string"
 		},
 		{
@@ -17876,7 +17876,7 @@
 		},
 		{
 			"key": "responseSchema422CredentialsIssue",
-			"value": "{\"description\":\"ErrUnknownIssuer is returned when the implementation does not have private\\nkey material for the requested `issuer`, and is therefore unable to issue\\nthe requested credential.\\n\",\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":{\"message\":{\"enum\":[\"Unknown Issuer: Unable to issue credentials for specified issuer\"]}}}]}",
+			"value": "{\"description\":\"ErrUnknownIssuer is returned when the implementation does not have private\\nkey material for the requested `issuer`, and is therefore unable to issue\\nthe requested credential.\\n\",\"allOf\":[{\"type\":\"object\",\"required\":[\"message\"],\"properties\":{\"message\":{\"type\":\"string\"},\"details\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}},{\"type\":\"object\",\"additionalProperties\":true}]}}},{\"type\":\"object\",\"properties\":\"message\"}]}",
 			"type": "string"
 		}
 	]


### PR DESCRIPTION
We had a prior agreement on a call, that we should specify the shape of the errors, but we do not need to specify the exact value of the error message.