### PR TITLE
fix: add token audience for workflow tutorial

### DIFF
--- a/docs/tutorials/traceable-presentation-workflow/traceable-presentation-workflow.postman_collection.json
+++ b/docs/tutorials/traceable-presentation-workflow/traceable-presentation-workflow.postman_collection.json
@@ -65,6 +65,11 @@
 					"mode": "urlencoded",
 					"urlencoded": [
 						{
+							"key": "audience",
+							"value": "{{TOKEN_AUDIENCE}}",
+							"type": "text"
+						},
+						{
 							"key": "client_id",
 							"value": "{{CLIENT_ID}}",
 							"type": "text"


### PR DESCRIPTION
This PR adds a missing `audience` key to the request body for getting a token in the workflow tutorial.