### PR TITLE
chore: remove scope from interop suite

### DIFF
--- a/docs/tutorials/agility/agility.collection.json
+++ b/docs/tutorials/agility/agility.collection.json
@@ -52,7 +52,7 @@
 						},
 						{
 							"key": "scope",
-							"value": "resolve:dids issue:credentials",
+							"value": "{{CLIENT_SCOPE}}",
 							"type": "text"
 						}
 					]

--- a/docs/tutorials/authentication/authentication.postman_collection.json
+++ b/docs/tutorials/authentication/authentication.postman_collection.json
@@ -71,6 +71,11 @@
 							"key": "grant_type",
 							"value": "client_credentials",
 							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "{{CLIENT_SCOPE}}",
+							"type": "text"
 						}
 					]
 				},

--- a/docs/tutorials/credentials-issue/credentials-issue.postman_collection.json
+++ b/docs/tutorials/credentials-issue/credentials-issue.postman_collection.json
@@ -82,7 +82,7 @@
 						},
 						{
 							"key": "scope",
-							"value": "resolve:dids issue:credentials",
+							"value": "{{CLIENT_SCOPE}}",
 							"type": "text"
 						}
 					]

--- a/docs/tutorials/credentials-revocation/credentials-revocation.postman_collection.json
+++ b/docs/tutorials/credentials-revocation/credentials-revocation.postman_collection.json
@@ -83,7 +83,7 @@
 						},
 						{
 							"key": "scope",
-							"value": "resolve:dids issue:credentials verify:credentials update:credentials",
+							"value": "{{CLIENT_SCOPE}}",
 							"type": "text"
 						}
 					]

--- a/docs/tutorials/credentials-status-update/credentials-status-update.postman_collection.json
+++ b/docs/tutorials/credentials-status-update/credentials-status-update.postman_collection.json
@@ -83,7 +83,7 @@
 						},
 						{
 							"key": "scope",
-							"value": "resolve:dids issue:credentials verify:credentials update:credentials",
+							"value": "{{CLIENT_SCOPE}}",
 							"type": "text"
 						}
 					]

--- a/docs/tutorials/credentials-verify/credentials-verify.postman_collection.json
+++ b/docs/tutorials/credentials-verify/credentials-verify.postman_collection.json
@@ -82,7 +82,7 @@
 						},
 						{
 							"key": "scope",
-							"value": "resolve:dids issue:credentials verify:credentials",
+							"value": "{{CLIENT_SCOPE}}",
 							"type": "text"
 						}
 					]

--- a/docs/tutorials/did-web-discovery/did-web-discovery.postman_collection.json
+++ b/docs/tutorials/did-web-discovery/did-web-discovery.postman_collection.json
@@ -82,7 +82,7 @@
 						},
 						{
 							"key": "scope",
-							"value": "resolve:dids",
+							"value": "{{CLIENT_SCOPE}}",
 							"type": "text"
 						}
 					]

--- a/docs/tutorials/presentations-exchange-oauth/presentations-exchange-oauth.json
+++ b/docs/tutorials/presentations-exchange-oauth/presentations-exchange-oauth.json
@@ -86,7 +86,7 @@
 						},
 						{
 							"key": "scope",
-							"value": "resolve:dids submit:presentations",
+							"value": "{{VERIFIER_CLIENT_SCOPE}}",
 							"type": "text"
 						}
 					]

--- a/docs/tutorials/traceable-presentation-workflow/traceable-presentation-workflow.postman_collection.json
+++ b/docs/tutorials/traceable-presentation-workflow/traceable-presentation-workflow.postman_collection.json
@@ -81,7 +81,7 @@
 						},
 						{
 							"key": "scope",
-							"value": "resolve:dids submit:presentations",
+							"value": "{{CLIENT_SCOPE}}",
 							"type": "text"
 						}
 					]

--- a/docs/tutorials/vc-jwt/vc-jwt.collection.json
+++ b/docs/tutorials/vc-jwt/vc-jwt.collection.json
@@ -52,7 +52,7 @@
 						},
 						{
 							"key": "scope",
-							"value": "resolve:dids issue:credentials verify:credentials",
+							"value": "{{CLIENT_SCOPE}}",
 							"type": "text"
 						}
 					]


### PR DESCRIPTION
This PR updates the `scope` body parameter to use an environment variable instead of hard-coded scope names per #457.

As a reminder, it is now assumed that OAuth providers will return *all* scopes granted to the client ID in use when no scope is named in the token request (the default behavior for many providers, e.g. Auth0), and that implementations which require a value to be present in the token request (e.g., Azure) must provide a value for the `CLIENT_SCOPE` environment variable.

Fixes #550