### PR TITLE
fix: pass scope in env var

### DIFF
--- a/.github/workflows/interoperability-report.yml
+++ b/.github/workflows/interoperability-report.yml
@@ -37,6 +37,7 @@ jobs:
           organization_did_web: ${{secrets[format('{0}_ORGANIZATION_DID_WEB', matrix.actor)]}}
           client_id: ${{secrets[format('{0}_CLIENT_ID', matrix.actor)]}}
           client_secret: ${{secrets[format('{0}_CLIENT_SECRET', matrix.actor)]}}
+          client_scope:  ${{secrets[format('{0}_CLIENT_SCOPE', matrix.actor)]}}
           token_audience: ${{secrets[format('{0}_TOKEN_AUDIENCE', matrix.actor)]}}
           token_endpoint: ${{secrets[format('{0}_TOKEN_ENDPOINT', matrix.actor)]}}
           api_base_url: ${{secrets[format('{0}_API_BASE_URL', matrix.actor)]}}
@@ -45,6 +46,7 @@ jobs:
           --env-var ORGANIZATION_DID_WEB=$organization_did_web \
           --env-var CLIENT_ID=$client_id \
           --env-var CLIENT_SECRET=$client_secret \
+          --env-var CLIENT_SCOPE=$client_scope \
           --env-var TOKEN_AUDIENCE=$token_audience \
           --env-var TOKEN_ENDPOINT=$token_endpoint \
           --env-var API_BASE_URL=$api_base_url \
@@ -94,6 +96,7 @@ jobs:
           organization_did_web: ${{secrets[format('{0}_ORGANIZATION_DID_WEB', matrix.actor)]}}
           client_id: ${{secrets[format('{0}_CLIENT_ID', matrix.actor)]}}
           client_secret: ${{secrets[format('{0}_CLIENT_SECRET', matrix.actor)]}}
+          client_scope:  ${{secrets[format('{0}_CLIENT_SCOPE', matrix.actor)]}}
           token_audience: ${{secrets[format('{0}_TOKEN_AUDIENCE', matrix.actor)]}}
           token_endpoint: ${{secrets[format('{0}_TOKEN_ENDPOINT', matrix.actor)]}}
           api_base_url: ${{secrets[format('{0}_API_BASE_URL', matrix.actor)]}}
@@ -102,6 +105,7 @@ jobs:
           --env-var ORGANIZATION_DID_WEB=$organization_did_web \
           --env-var CLIENT_ID=$client_id \
           --env-var CLIENT_SECRET=$client_secret \
+          --env-var CLIENT_SCOPE=$client_scope \
           --env-var TOKEN_AUDIENCE=$token_audience \
           --env-var TOKEN_ENDPOINT=$token_endpoint \
           --env-var API_BASE_URL=$api_base_url \
@@ -151,6 +155,7 @@ jobs:
           organization_did_web: ${{secrets[format('{0}_ORGANIZATION_DID_WEB', matrix.actor)]}}
           client_id: ${{secrets[format('{0}_CLIENT_ID', matrix.actor)]}}
           client_secret: ${{secrets[format('{0}_CLIENT_SECRET', matrix.actor)]}}
+          client_scope:  ${{secrets[format('{0}_CLIENT_SCOPE', matrix.actor)]}}
           token_audience: ${{secrets[format('{0}_TOKEN_AUDIENCE', matrix.actor)]}}
           token_endpoint: ${{secrets[format('{0}_TOKEN_ENDPOINT', matrix.actor)]}}
           api_base_url: ${{secrets[format('{0}_API_BASE_URL', matrix.actor)]}}
@@ -159,6 +164,7 @@ jobs:
           --env-var ORGANIZATION_DID_WEB=$organization_did_web \
           --env-var CLIENT_ID=$client_id \
           --env-var CLIENT_SECRET=$client_secret \
+          --env-var CLIENT_SCOPE=$client_scope \
           --env-var TOKEN_AUDIENCE=$token_audience \
           --env-var TOKEN_ENDPOINT=$token_endpoint \
           --env-var API_BASE_URL=$api_base_url \
@@ -236,12 +242,14 @@ jobs:
           holder_organization_did_web: ${{secrets[format('{0}_ORGANIZATION_DID_WEB', matrix.holder)]}}
           holder_client_id: ${{secrets[format('{0}_CLIENT_ID', matrix.holder)]}}
           holder_client_secret: ${{secrets[format('{0}_CLIENT_SECRET', matrix.holder)]}}
+          holder_client_scope:  ${{secrets[format('{0}_CLIENT_SCOPE', matrix.actor)]}}
           holder_token_audience: ${{secrets[format('{0}_TOKEN_AUDIENCE', matrix.holder)]}}
           holder_token_endpoint: ${{secrets[format('{0}_TOKEN_ENDPOINT', matrix.holder)]}}
           holder_api_base_url: ${{secrets[format('{0}_API_BASE_URL', matrix.holder)]}}
           verifier_organization_did_web: ${{secrets[format('{0}_ORGANIZATION_DID_WEB', matrix.verifier)]}}
           verifier_client_id: ${{secrets[format('{0}_CLIENT_ID', matrix.verifier)]}}
           verifier_client_secret: ${{secrets[format('{0}_CLIENT_SECRET', matrix.verifier)]}}
+          verifier_client_scope:  ${{secrets[format('{0}_CLIENT_SCOPE', matrix.actor)]}}
           verifier_token_audience: ${{secrets[format('{0}_TOKEN_AUDIENCE', matrix.verifier)]}}
           verifier_token_endpoint: ${{secrets[format('{0}_TOKEN_ENDPOINT', matrix.verifier)]}}
           verifier_api_base_url: ${{secrets[format('{0}_API_BASE_URL', matrix.verifier)]}}
@@ -250,12 +258,14 @@ jobs:
           --env-var HOLDER_ORGANIZATION_DID_WEB=$holder_organization_did_web \
           --env-var HOLDER_CLIENT_ID=$holder_client_id \
           --env-var HOLDER_CLIENT_SECRET=$holder_client_secret \
+          --env-var HOLDER_CLIENT_SCOPE=$holder_client_scope \
           --env-var HOLDER_TOKEN_AUDIENCE=$holder_token_audience \
           --env-var HOLDER_TOKEN_ENDPOINT=$holder_token_endpoint \
           --env-var HOLDER_API_BASE_URL=$holder_api_base_url \
           --env-var VERIFIER_ORGANIZATION_DID_WEB=$verifier_organization_did_web \
           --env-var VERIFIER_CLIENT_ID=$verifier_client_id \
           --env-var VERIFIER_CLIENT_SECRET=$verifier_client_secret \
+          --env-var VERIFIER_CLIENT_SCOPE=$verifier_client_scope \
           --env-var VERIFIER_TOKEN_AUDIENCE=$verifier_token_audience \
           --env-var VERIFIER_TOKEN_ENDPOINT=$verifier_token_endpoint \
           --env-var VERIFIER_API_BASE_URL=$verifier_api_base_url \
@@ -305,6 +315,7 @@ jobs:
           organization_did_web: ${{secrets[format('{0}_ORGANIZATION_DID_WEB', matrix.actor)]}}
           client_id: ${{secrets[format('{0}_CLIENT_ID', matrix.actor)]}}
           client_secret: ${{secrets[format('{0}_CLIENT_SECRET', matrix.actor)]}}
+          client_scope:  ${{secrets[format('{0}_CLIENT_SCOPE', matrix.actor)]}}
           token_audience: ${{secrets[format('{0}_TOKEN_AUDIENCE', matrix.actor)]}}
           token_endpoint: ${{secrets[format('{0}_TOKEN_ENDPOINT', matrix.actor)]}}
           api_base_url: ${{secrets[format('{0}_API_BASE_URL', matrix.actor)]}}
@@ -313,6 +324,8 @@ jobs:
           --env-var ORGANIZATION_DID_WEB=$organization_did_web \
           --env-var CLIENT_ID=$client_id \
           --env-var CLIENT_SECRET=$client_secret \
+          --env-var CLIENT_SCOPE=$client_scope \
+          --env-var TOKEN_AUDIENCE=$token_audience \
           --env-var TOKEN_ENDPOINT=$token_endpoint \
           --env-var API_BASE_URL=$api_base_url \
           --reporters cli,htmlextra,json \
@@ -361,6 +374,7 @@ jobs:
           organization_did_web: ${{secrets[format('{0}_ORGANIZATION_DID_WEB', matrix.actor)]}}
           client_id: ${{secrets[format('{0}_CLIENT_ID', matrix.actor)]}}
           client_secret: ${{secrets[format('{0}_CLIENT_SECRET', matrix.actor)]}}
+          client_scope:  ${{secrets[format('{0}_CLIENT_SCOPE', matrix.actor)]}}
           token_audience: ${{secrets[format('{0}_TOKEN_AUDIENCE', matrix.actor)]}}
           token_endpoint: ${{secrets[format('{0}_TOKEN_ENDPOINT', matrix.actor)]}}
           api_base_url: ${{secrets[format('{0}_API_BASE_URL', matrix.actor)]}}
@@ -369,6 +383,7 @@ jobs:
           --env-var ORGANIZATION_DID_WEB=$organization_did_web \
           --env-var CLIENT_ID=$client_id \
           --env-var CLIENT_SECRET=$client_secret \
+          --env-var CLIENT_SCOPE=$client_scope \
           --env-var TOKEN_AUDIENCE=$token_audience \
           --env-var TOKEN_ENDPOINT=$token_endpoint \
           --env-var API_BASE_URL=$api_base_url \


### PR DESCRIPTION
This PR ensures that values from repository secrets are passed for the CLIENT_SCOPE environment variables for interop testing.