### PR TITLE
Bringing together scattered workflow NDRs, moving it to vocab

### DIFF
--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -323,78 +323,6 @@
   </section>
 
   <section class="normative">
-    <h2>Workflows</h2>
-    <p>
-      <em>Workflows</em> are a critical concept in this specification that enable presenters to correlate individual presentations. A <em>Workflow Definition</em> can be used to indicate that a presentation intends to meet a defined set of data requirements; a <em>Workflow Instance</em> indicates that a presentation should be considered in conjunction with other presentations. 
-    </p>
-    <p>
-      The data model for indicating Workflow identifiers on Traceable Presentations is defined in <a href="https://w3c-ccg.github.io/traceability-interop/draft/#presentations">https://w3c-ccg.github.io/traceability-interop/draft/#presentations</a>. 
-    </p>
-    <h3>Workflow Definitions</h3>
-    <p>
-      A Workflow Definition <em>MUST</em> be defined by a URN which resolves to a workflow definition manifest file.
-    </p>
-    <p>
-      The workflow definition manifest YAML file defines:
-      <ul>
-        <li>`id` — identifier to be referenced.</li>
-        <li>`title` — a title of the workflow definition</li>
-        <li>`description` — indicates applicable circumstances and expected procedures for the workflow</li>
-        <li>`tags` — listing applicable industry verticals</li>
-        <li>`credentials` — listing verifiable credentials types which are required to attain the goals of the workflow</li>
-        <li>`mermaid` — diagram which contextualizes the involved workflow parties and their roles</li>
-      </ul>
-    </p>
-      <h4>Referencing Workflow Definition</h4>
-    <p>
-      By referencing a Workflow Definition `id` in a Traceable Presentation, the holder indicates to the verifier the intention of making the presentation.
-    </p>
-    <p>
-      For example, <a href="https://w3id.org/traceability/#us-cbp-entry">https://w3id.org/traceability/#us-cbp-entry</a> indicates that an Importer intends to import goods following common US CBP Entry filings.
-    </p>
-    <p>      
-      Multiple Workflow Definitions <em>MAY</em> be referenced by a Traceable Presentation, indicating that multiple relevant circumstances apply. 
-    </p>
-    <p>      
-      For example, when <a href="https://w3id.org/traceability/#us-cbp-entry">https://w3id.org/traceability/#us-cbp-entry</a> and <a href="https://w3id.org/traceability/#importer-security-filing">https://w3id.org/traceability/#importer-security-filing</a> are together, they indicate that goods are arriving by vessel, so the entry is subject to Importer Security Filings in addition to the Common CBP Entry Filings. 
-    </p>
-    <h3>Workflow Instances</h3>    
-    <p>
-      A Workflow Instance <em>MUST</em> be defined by a URN for a UUID v4. 
-    </p>
-    <p>
-      By referencing the same Workflow Instance `id` in separate Traceable Presentations, the holder indicates to the verifier that the presentations are related. 
-    </p>
-    <p>
-      For example, an initial presentation of an Intent to Import Credential may be followed at a later date by presentation of a Commercial Invoice Credential. The two presentations reference a common Workflow Instance identifier to indicate that they relate to the same shipment import.
-    </p>
-    <h4>Multiple Holders Referencing a Workflow Instance</h4>
-    <p>
-      Multiple holders <em>MAY</em> reference the same Workflow Instance `id` in their Traceable Presentations. In the context of customs procedures, a Workflow Instance can be thought of as the traditional "pouch" of documents filed for clearance.
-    </p>
-    <p>
-      As an example, after having verified import-related credential, the customs authority references the same Workflow Instance `id` when presenting a customs release credential back to the importer. 
-    </p>
-    <p>
-      Another common example is when separate issuers are filing credentials related to the same import, such as an Importer of Record and a Freight Forwarder making presentations related to the same shipment import. 
-    </p>
-    <h4>Referencing Multiple Instances</h4>
-    <p>
-      The same Traceable Presentation <em>MAY</em> reference multiple Workflow Instances. This is an indication by the holder that the verifier should consider the two Workflow Instances as one. 
-    </p>
-    <p>
-      For example, an Importer of Record and a Freight Forwarder may have initially made presentations to Customs related to the same shipment; when either of them becomes aware of the other Workflow Instance `id`, including both `id`s in the same Traceable Presentation indicates to Customs that the two instances are part of the same shipment import. 
-    </p>
-    <h4>Relation to Workflow Definitions</h4>
-    <p>
-      A Workflow Instance <em>CAN</em> be related to one or more Workflow Definitions. This is done by referencing a Workflow Instance `id` and one or more Workflow Definition `id`s from the same Traceable Presentation. 
-    </p>
-    <p>
-      This way, the Workflow Instance's progress can be tracked by comparing the credentials which have been presented within the Workflow Instance (numerator) against the combined set of credentials types required by the targeted Workflow Definitions (denominator). 
-    </p>
-  </section>
-
-  <section class="normative">
     <h2>Rules for Processing Data</h2>
     <p>
       Data exchanged according to this specification will often need to
@@ -432,33 +360,11 @@
         <h2>Presentations</h2>
         <p>
           Presentations in this spec are
-          <a href="https://w3id.org/traceability/#TraceablePresentation">Traceable
+          <a href="https://w3id.org/traceability/#traceable-presentation">Traceable
             Presentations</a>, which contain several notable identifiers
           that can be used for correlation, retrieval, and business rule
           processing of data.
         </p>
-        These identifiers are:
-        <ul>
-          <li>
-            `TraceablePresentation.id` — The unique ID of the
-            presentation itself; think of this as identifying the wire
-            transaction. This ID MUST be a UUID v4 per [[rfc4122]].
-          </li>
-          <li>
-            `TraceablePresentation.workflow.definition` — The ID for the
-            workflow definition, or the <em>type</em> of workflow that
-            the presented credentials belong to. This ID MUST be a URN for a UUID
-            v4 per [[rfc4122]], e.g., `urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6`.
-          </li>
-          <li>
-            `TraceablePresentation.workflow.instance` — The ID for the
-            unique instance of the workflow, e.g., party A sending goods
-            of a certain type (with particular data requirements to meet
-            regulatory needs) to party B using workflow type X as
-            defined by `TraceablePresentation.workflow.definition`. This
-            ID MUST be a UUID v4 per [[rfc4122]].
-          </li>
-        </ul>
         <p>
           `TraceablePresentation.id` <em>MUST</em> be unique to each
           presentation. A presentation received with a duplicate ID
@@ -467,29 +373,16 @@
           <em>SHOULD</em> generate a new presentation, with a new UUID
           v4 for the ID and then retry the presentation.
         </p>
-        <p class="issue" data-number="502">
-          The handling of duplicated `TraceablePresentation.id` requires discussion
-          and consensus.
-        </p>
-        <p class="issue" data-number="485">
-          There is active discussion regarding the addition of a member to a
-          <a href="https://w3id.org/traceability/#TraceablePresentation">Traceable
-            Presentation</a>
-          with the name `replacesPresentation`. If this member is
-          present, its value <em>SHOULD</em> be an ID of a prior
-          presentation and <em>SHOULD</em> act as a signal to replace
-          the prior presentation and any credentials contained within,
-          and to prefer credentials in the new presentation.
+        <p>
+          The holder <em>MAY</em> indicate replacement of a previously sent 
+          <a href="https://w3id.org/traceability/#traceable-presentation">Traceable
+            Presentation</a> with the `replace` property. 
+          If this member is present, its value <em>SHOULD</em> be interpreted as defined in 
+          <a href="https://w3id.org/traceability/#presentation-replace">Presentation Replace</a>.
         </p>
         <p>
-          To assemble a collection of Credentials linked together by a
-          workflow, data may be queried by a combination of
-          `TraceablePresentation.workflow.definition` and
-          `TraceablePresentation.workflow.instance`, assuming that the
-          implementation's underlying data store persists presentation
-          metadata upon receipt. Rules for ensuring the retrieval of the
-          most "correct" credentials associated for that workflow
-          instance are covered below in the section on Credentials.
+          Multiple Traceable Presentations <em>MAY</em> be correlated by referencing 
+          a <a href="https://w3id.org/traceability/#workflow">Workflow</a>.
         </p>
 
         <p class="issue" data-number="496">


### PR DESCRIPTION
This cleans up redundant specifications of workflows, moving the definitions to vocab (as agreed: https://github.com/w3c-ccg/traceability-interop/issues/502). 

The good parts I've copied over to vocab here: https://github.com/w3c-ccg/traceability-vocab/pull/856. 

Closes https://github.com/w3c-ccg/traceability-interop/issues/502
Closes https://github.com/w3c-ccg/traceability-interop/issues/485