### PR TITLE
chore: add test for duplicate issuer value

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -425,64 +425,6 @@
 							"name": "Bad Request",
 							"item": [
 								{
-									"name": "Duplicate Keys",
-									"item": [
-										{
-											"name": "credentials_issue.credential.issuer:dup",
-											"event": [
-												{
-													"listen": "test",
-													"script": {
-														"exec": [
-															"pm.test(\"status code is 400\", function () {",
-															" pm.response.to.have.status(400);",
-															"});",
-															"",
-															"pm.test(\"response validates against schema\", function() {",
-															" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
-															" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
-															"});",
-															"",
-															""
-														],
-														"type": "text/javascript"
-													}
-												}
-											],
-											"request": {
-												"method": "POST",
-												"header": [
-													{
-														"key": "Accept",
-														"value": "application/json",
-														"type": "text"
-													}
-												],
-												"body": {
-													"mode": "raw",
-													"raw": "{\n    \"credential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"issuer\": \"{{issuer}}\",\n        \"issuer\": \"{{issuer}}\",\n        \"issuanceDate\": \"{{issuanceDate}}\",\n        \"credentialSubject\": {\"foo\": \"bar\"}\n    },\n    \"options\": {\n        \"type\": \"Ed25519Signature2018\"\n    }\n}",
-													"options": {
-														"raw": {
-															"language": "text"
-														}
-													}
-												},
-												"url": {
-													"raw": "{{API_BASE_URL}}/credentials/issue",
-													"host": [
-														"{{API_BASE_URL}}"
-													],
-													"path": [
-														"credentials",
-														"issue"
-													]
-												}
-											},
-											"response": []
-										}
-									]
-								},
-								{
 									"name": "credentials_issue:credential:missing",
 									"event": [
 										{
@@ -6630,6 +6572,76 @@
 				{
 					"name": "Positive Testing",
 					"item": [
+						{
+							"name": "Duplicate Keys",
+							"item": [
+								{
+									"name": "credentials_issue.credential.issuer:dup",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 201\", function () {",
+													" pm.response.to.have.status(201);",
+													"});",
+													"",
+													"pm.test(\"response issuer matches request credential.issuer\", function() {",
+													" const { issuer } = pm.response.json().verifiableCredential;",
+													" pm.expect(issuer).to.equal(pm.variables.get(\"issuer\"))",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema201CredentialsIssue\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Accept",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"credential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"issuer\": \"{{issuer}}-ignored\",\n        \"issuer\": \"{{issuer}}\",\n        \"issuanceDate\": \"{{issuanceDate}}\",\n        \"credentialSubject\": {\"foo\": \"bar\"}\n    },\n    \"options\": {\n        \"type\": \"Ed25519Signature2018\"\n    }\n}",
+											"options": {
+												"raw": {
+													"language": "text"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/issue",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"issue"
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
 						{
 							"name": "credentials_issue",
 							"event": [

--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -425,6 +425,64 @@
 							"name": "Bad Request",
 							"item": [
 								{
+									"name": "Duplicate Keys",
+									"item": [
+										{
+											"name": "credentials_issue.credential.issuer:dup",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"status code is 400\", function () {",
+															" pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"response validates against schema\", function() {",
+															" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+															" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+															"});",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Accept",
+														"value": "application/json",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"credential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://w3id.org/traceability/v1\"\n        ],\n        \"type\": [\n            \"VerifiableCredential\"\n        ],\n        \"issuer\": \"{{issuer}}\",\n        \"issuer\": \"{{issuer}}\",\n        \"issuanceDate\": \"{{issuanceDate}}\",\n        \"credentialSubject\": {\"foo\": \"bar\"}\n    },\n    \"options\": {\n        \"type\": \"Ed25519Signature2018\"\n    }\n}",
+													"options": {
+														"raw": {
+															"language": "text"
+														}
+													}
+												},
+												"url": {
+													"raw": "{{API_BASE_URL}}/credentials/issue",
+													"host": [
+														"{{API_BASE_URL}}"
+													],
+													"path": [
+														"credentials",
+														"issue"
+													]
+												}
+											},
+											"response": []
+										}
+									]
+								},
+								{
 									"name": "credentials_issue:credential:missing",
 									"event": [
 										{


### PR DESCRIPTION
This PR adds a negative conformance test for duplicate JSON key `issuer` in a credentials issue request. The expectation is that the issuer will return a 400 error response.

This test is added into a new sub-folder called "Duplicate Keys" because any tests like this will differ from our standard tests in that it is not a simple mutation of the minimal request JSON object (you can't add duplicate keys in JSON). If we add more tests here,  each one will have a request body in raw text (not JSON) that includes the minimal credentials issue request with the appropriate key duplicated.

When we discuss this on call, we should determine whether or not we feel we need duplicate key tests for all keys.

Fixes #539