### PR TITLE
docs: add code generation section to respec

### DIFF
--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -99,7 +99,7 @@
             url: 'https://github.com/brownoxford',
             company: 'mesur.io',
             companyURL: 'https://www.mesur.io/',
-          },       
+          },
           {
             name: 'Russell Hofvendahl',
             url: 'https://github.com/rhofvendahl',
@@ -147,7 +147,7 @@
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
       // wgPatentURI:  "",
-      
+
       maxTocLevel: 2,
       localBiblio: {
         'VC-DI-BBS': {
@@ -301,7 +301,7 @@
 
   <section id="conformance"></section>
 
-  
+
 
   <section id="terminology" class="informative">
     <h2>Terminology</h2>
@@ -374,14 +374,14 @@
           v4 for the ID and then retry the presentation.
         </p>
         <p>
-          The holder <em>MAY</em> indicate replacement of a previously sent 
+          The holder <em>MAY</em> indicate replacement of a previously sent
           <a href="https://w3id.org/traceability/#traceable-presentation">Traceable
-            Presentation</a> with the `replace` property. 
-          If this member is present, its value <em>SHOULD</em> be interpreted as defined in 
+            Presentation</a> with the `replace` property.
+          If this member is present, its value <em>SHOULD</em> be interpreted as defined in
           <a href="https://w3id.org/traceability/#presentation-replace">Presentation Replace</a>.
         </p>
         <p>
-          Multiple Traceable Presentations <em>MAY</em> be correlated by referencing 
+          Multiple Traceable Presentations <em>MAY</em> be correlated by referencing
           a <a href="https://w3id.org/traceability/#workflow">Workflow</a>.
         </p>
 
@@ -507,7 +507,7 @@
     <pre class="example">
           servers:
             - url: https://conformant-platform.example.com
-   </pre>
+    </pre>
     <p>Add the target <code>tokenUrl</code>:</p>
     <pre class="example">
         components:
@@ -517,7 +517,28 @@
               flows:
                 clientCredentials:
                   tokenUrl: https://conformant-platform.example.com/oauth/token
-   </pre>
+    </pre>
+    <h3>Code Generation</h3>
+    <p>
+      The <a href=""><code>openapi-typescript-codegen</code></a> project provides
+      a means for generating typescript clients based on OpenAPI specifications.
+    </p>
+    <pre class="example">
+      # Install openapi-typescript-codegen globally
+      npm install -g openapi-typescript-codegen
+
+      # Produce a dereferenced openapi specification JSON file from this repo.
+      npm run preserve
+
+      # Generate a typescript client from the dereferenced openapi specification JSON file.
+      npx openapi-typescript-codegen --input ./docs/openapi/openapi.json
+    </pre>
+    <p>
+      Please refer to the `openapi-typescript-codegen` project page for more detailed
+      <a href="https://github.com/ferdikoomen/openapi-typescript-codegen/tree/master#install">installation</a>
+      and <a href="https://github.com/ferdikoomen/openapi-typescript-codegen/tree/master#usage">usage</a>
+      instructions.
+    </p>
   </section>
 
   <section class="normative">
@@ -651,7 +672,7 @@
       </p>
     </section>
 
-   
+
 
     <section class="informative">
       <h2>Threat Model</h2>


### PR DESCRIPTION
This PR adds a "Code Generation" section to the respec document, with example and links for typescript client code generation from the OpenAPI specification.

Fixes #503