### PR TITLE
Update Accept header to application/vc+ld+json

### DIFF
--- a/docs/openapi/parameters/header/accept.yml
+++ b/docs/openapi/parameters/header/accept.yml
@@ -5,4 +5,4 @@ description: A verifiable credential format
 example: "application/vc+ld+json"
 schema:
   type: string
-  enum: ["application/vc+ld+json+sd-jwt", "application/vc+ld+json"]
+  enum: ["application/sd-jwt", "application/vc+ld+json"]

--- a/docs/tutorials/credentials-issue/README.md
+++ b/docs/tutorials/credentials-issue/README.md
@@ -228,7 +228,7 @@ Create a new `GET` request called "Issue Credential" in the "Credentials Issue T
 
 * Set the request URL to `{{API_BASE_URL}}/credentials/issue`.
 * In the "Auth" tab, add `{{access_token}}` as the "Token" value.
-* In the "Headers" tab, dd an `Accept` header with the value `application/json`.
+* In the "Headers" tab, dd an `Accept` header with the value `application/vc+ld+json`.
 * In the body tab, add the following JSON:
   ```json
   {

--- a/docs/tutorials/credentials-issue/credentials-issue.postman_collection.json
+++ b/docs/tutorials/credentials-issue/credentials-issue.postman_collection.json
@@ -228,7 +228,7 @@
 				"header": [
 					{
 						"key": "Accept",
-						"value": "application/json",
+						"value": "application/vc+ld+json",
 						"type": "text"
 					}
 				],

--- a/docs/tutorials/credentials-revocation/credentials-revocation.postman_collection.json
+++ b/docs/tutorials/credentials-revocation/credentials-revocation.postman_collection.json
@@ -234,7 +234,7 @@
 				"header": [
 					{
 						"key": "Accept",
-						"value": "application/json",
+						"value": "application/vc+ld+json",
 						"type": "text"
 					}
 				],

--- a/docs/tutorials/credentials-status-update/credentials-status-update.postman_collection.json
+++ b/docs/tutorials/credentials-status-update/credentials-status-update.postman_collection.json
@@ -234,7 +234,7 @@
 				"header": [
 					{
 						"key": "Accept",
-						"value": "application/json",
+						"value": "application/vc+ld+json",
 						"type": "text"
 					}
 				],

--- a/docs/tutorials/credentials-verify/credentials-verify.postman_collection.json
+++ b/docs/tutorials/credentials-verify/credentials-verify.postman_collection.json
@@ -234,7 +234,7 @@
 				"header": [
 					{
 						"key": "Accept",
-						"value": "application/json",
+						"value": "application/vc+ld+json",
 						"type": "text"
 					}
 				],

--- a/docs/tutorials/vc-jwt/vc-jwt.collection.json
+++ b/docs/tutorials/vc-jwt/vc-jwt.collection.json
@@ -156,7 +156,7 @@
 				"header": [
 					{
 						"key": "Accept",
-						"value": "application/json",
+						"value": "application/vc+ld+json+sd-jwt",
 						"type": "text"
 					}
 				],

--- a/docs/tutorials/vc-jwt/vc-jwt.collection.json
+++ b/docs/tutorials/vc-jwt/vc-jwt.collection.json
@@ -156,7 +156,7 @@
 				"header": [
 					{
 						"key": "Accept",
-						"value": "application/vc+ld+json+sd-jwt",
+						"value": "application/sd-jwt",
 						"type": "text"
 					}
 				],

--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -464,7 +464,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -530,7 +530,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -596,7 +596,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -662,7 +662,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -728,7 +728,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -794,7 +794,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -860,7 +860,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -929,7 +929,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -998,7 +998,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -1067,7 +1067,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -1136,7 +1136,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -1205,7 +1205,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -1271,7 +1271,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -1337,7 +1337,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -1403,7 +1403,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -1469,7 +1469,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -1535,7 +1535,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -1600,7 +1600,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -1665,7 +1665,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -1730,7 +1730,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -1795,7 +1795,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -1860,7 +1860,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -1925,7 +1925,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -1990,7 +1990,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -2058,7 +2058,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -2126,7 +2126,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -2194,7 +2194,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -2262,7 +2262,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -2330,7 +2330,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -2395,7 +2395,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -2460,7 +2460,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -2525,7 +2525,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -2590,7 +2590,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -2655,7 +2655,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -2720,7 +2720,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -2784,7 +2784,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -2849,7 +2849,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -2914,7 +2914,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -2979,7 +2979,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -3044,7 +3044,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -3109,7 +3109,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -3174,7 +3174,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -3239,7 +3239,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -3304,7 +3304,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -3369,7 +3369,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -3434,7 +3434,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -3499,7 +3499,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -3564,7 +3564,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -3629,7 +3629,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -3694,7 +3694,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -3759,7 +3759,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -3824,7 +3824,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -3889,7 +3889,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -3954,7 +3954,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -4019,7 +4019,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -4084,7 +4084,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -4149,7 +4149,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -4214,7 +4214,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -4279,7 +4279,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -4344,7 +4344,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -4409,7 +4409,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -4474,7 +4474,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -4539,7 +4539,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -4604,7 +4604,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -4669,7 +4669,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -4734,7 +4734,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -4799,7 +4799,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -4864,7 +4864,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -4929,7 +4929,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -4994,7 +4994,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -5059,7 +5059,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -5124,7 +5124,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -5189,7 +5189,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -5254,7 +5254,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -5319,7 +5319,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -5384,7 +5384,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -5449,7 +5449,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -5514,7 +5514,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -5579,7 +5579,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -5644,7 +5644,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -5709,7 +5709,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -5774,7 +5774,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -5839,7 +5839,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -5904,7 +5904,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -5969,7 +5969,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -6034,7 +6034,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -6099,7 +6099,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -6164,7 +6164,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -6229,7 +6229,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -6294,7 +6294,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -6359,7 +6359,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -6422,7 +6422,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -6496,7 +6496,7 @@
 										"header": [
 											{
 												"key": "Accept",
-												"value": "application/json",
+												"value": "application/vc+ld+json",
 												"type": "text"
 											}
 										],
@@ -6627,7 +6627,7 @@
 								"header": [
 									{
 										"key": "Accept",
-										"value": "application/json",
+										"value": "application/vc+ld+json",
 										"type": "text"
 									}
 								],
@@ -6696,7 +6696,7 @@
 								"header": [
 									{
 										"key": "Accept",
-										"value": "application/json",
+										"value": "application/vc+ld+json",
 										"type": "text"
 									}
 								],
@@ -6771,7 +6771,7 @@
 								"header": [
 									{
 										"key": "Accept",
-										"value": "application/json",
+										"value": "application/vc+ld+json",
 										"type": "text"
 									}
 								],
@@ -6840,7 +6840,7 @@
 								"header": [
 									{
 										"key": "Accept",
-										"value": "application/json",
+										"value": "application/vc+ld+json",
 										"type": "text"
 									}
 								],
@@ -6908,7 +6908,7 @@
 								"header": [
 									{
 										"key": "Accept",
-										"value": "application/json",
+										"value": "application/vc+ld+json",
 										"type": "text"
 									}
 								],
@@ -6973,7 +6973,7 @@
 								"header": [
 									{
 										"key": "Accept",
-										"value": "application/json",
+										"value": "application/vc+ld+json",
 										"type": "text"
 									}
 								],


### PR DESCRIPTION
This PR updates references to `Accept` header in "Create Credentials" requests to use either `application/vc+ld+json` or `application/vc+ld+json+sd-jwt`, as discussed in issue https://github.com/w3c-ccg/traceability-interop/issues/574.

EDIT: using `application/sd-jwt` rather than `application/vc+ld+json+sd-jwt`, as discussed in 11/7/23 trace call.