### PR TITLE
Add negative test for missing accept header

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -6475,7 +6475,7 @@
 												"type": "text/javascript"
 											}
 										},
-                    {
+										{
 											"listen": "prerequest",
 											"script": {
 												"exec": [

--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -6452,6 +6452,72 @@
 							"description": "This folder contains requests which mutate a valid request body in a way that should provoke a \"400 Bad Request\" response from the server."
 						},
 						{
+							"name": "Bad Headers",
+							"item": [
+								{
+									"name": "credentials_issue:missing_header:accept",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"status code is 400\", function () {",
+													" pm.response.to.have.status(400);",
+													"});",
+													"",
+													"pm.test(\"response validates against schema\", function() {",
+													" const schemaString = pm.collectionVariables.get(\"responseSchema400\");",
+													" pm.response.to.have.jsonSchema(JSON.parse(schemaString));",
+													"});",
+													"",
+													""
+												],
+												"type": "text/javascript"
+											}
+										},
+                    {
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"// Request body must be serialized before sending over the wire.",
+													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
+													"    // noop",
+													"}));",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{{requestBody}}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{API_BASE_URL}}/credentials/issue",
+											"host": [
+												"{{API_BASE_URL}}"
+											],
+											"path": [
+												"credentials",
+												"issue"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"description": "This folder contains requests with missing or invalid headers that should provoke a \"400 Bad Request\" response from the server."
+						},
+						{
 							"name": "Bad Auth",
 							"item": [
 								{


### PR DESCRIPTION
This PR creates a test for credential creation which should fail if the server does not require an Accept header, as discussed in issue https://github.com/w3c-ccg/traceability-interop/issues/574.

NOTE: This will result in failed tests for all implementations which don't return `400` responses to requests without `Accept` headers.