### PR TITLE
chore: add postman documentation to respec

### DIFF
--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -447,11 +447,10 @@
       enrolling in continuous integration tests. These tests are based
       on Postman collections which orchestrate the interaction of
       participating parties, such as `Credential Issuance`, `Credential
-      Verification`, and `Presentation Exchange`. These Postman
-      collections are described with a set of
-      <a
-        href="https://w3id.org/traceability/interoperability/tree/main/docs/tutorials">tutorials</a>
-      that show how to run the tests against a particular implementation.
+      Verification`, and `Presentation Exchange`.
+      Please refer to the <a href="https://github.com/w3c-ccg/traceability-interop/tree/main/docs/tutorials">interoperability</a>
+      and <a href="https://github.com/w3c-ccg/traceability-interop/tree/main/tests">conformance</a>
+      documentation for details on how to import and run these Postman test suites.
     </p>
     <p>
       An interoperability report is continuously created from the


### PR DESCRIPTION
This PR adds links to the respec document so that users can find the tutorials on importing and running Postman interoperability and conformance testing suites.

Fixes #460