### PR TITLE
`credentialStatus` prerequest scripts create an additional array with the key `credentialstatus` (all lowercase)

### DIFF
--- a/tests/conformance_suite.postman_collection.json
+++ b/tests/conformance_suite.postman_collection.json
@@ -7659,7 +7659,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus must be array, not boolean",
-													"    req.credentialstatus = false;",
+													"    req.credentialStatus = false;",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -7724,7 +7724,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus must be array, not integer",
-													"    req.credentialstatus = 42;",
+													"    req.credentialStatus = 42;",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -7789,7 +7789,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus must be array, not null",
-													"    req.credentialstatus = null;",
+													"    req.credentialStatus = null;",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -7854,7 +7854,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus must be array, not object",
-													"    req.credentialstatus = {",
+													"    req.credentialStatus = {",
 													"        \"type\": \"RevocationList2020Status\",",
 													"        \"status\": \"0\"",
 													"    };",
@@ -7922,7 +7922,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus must be array, not string",
-													"    req.credentialstatus = \"RevocationList2020Status\";",
+													"    req.credentialStatus = \"RevocationList2020Status\";",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -7987,7 +7987,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus can only have zero or one elements.",
-													"    req.credentialstatus = [",
+													"    req.credentialStatus = [",
 													"        {",
 													"            \"type\": \"RevocationList2020Status\",",
 													"            \"status\": \"0\",",
@@ -8061,7 +8061,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus elements must be object, not array",
-													"    req.credentialstatus = [[]];",
+													"    req.credentialStatus = [[]];",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -8126,7 +8126,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus elements must be object, not boolean",
-													"    req.credentialstatus = [false];",
+													"    req.credentialStatus = [false];",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -8191,7 +8191,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus elements must be object, not integer",
-													"    req.credentialstatus = [42];",
+													"    req.credentialStatus = [42];",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -8256,7 +8256,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus elements must be object, not null",
-													"    req.credentialstatus = [null];",
+													"    req.credentialStatus = [null];",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -8321,7 +8321,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus elements must be object, not string",
-													"    req.credentialstatus = [\"RevocationList2020Status\"];",
+													"    req.credentialStatus = [\"RevocationList2020Status\"];",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -8386,7 +8386,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item type is a required property",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"status\": \"0\",",
 													"    }];",
 													"}));"
@@ -8453,7 +8453,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item type must be string, not array",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": [\"RevocationList2020Status\"],",
 													"        \"status\": \"0\",",
 													"    }];",
@@ -8521,7 +8521,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item type must be string, not boolean",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": false,",
 													"        \"status\": \"0\",",
 													"    }];",
@@ -8589,7 +8589,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item type must be string, not integer",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": 42,",
 													"        \"status\": \"0\",",
 													"    }];",
@@ -8657,7 +8657,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item type must be string, not null",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": null,",
 													"        \"status\": \"0\",",
 													"    }];",
@@ -8725,7 +8725,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item type must be string, not object",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": {},",
 													"        \"status\": \"0\",",
 													"    }];",
@@ -8793,7 +8793,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item type must be a valid value",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"invalid value\",",
 													"        \"status\": \"0\",",
 													"    }];",
@@ -8861,7 +8861,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status is a required property",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"RevocationList2020Status\",",
 													"    }];",
 													"}));"
@@ -8928,7 +8928,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not array",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"RevocationList2020Status\",",
 													"        \"status\": [\"0\"],",
 													"    }];",
@@ -8996,7 +8996,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not boolean",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"RevocationList2020Status\",",
 													"        \"status\": false,",
 													"    }];",
@@ -9064,7 +9064,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not integer",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"RevocationList2020Status\",",
 													"        \"status\": 1,",
 													"    }];",
@@ -9132,7 +9132,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not null",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"RevocationList2020Status\",",
 													"        \"status\": null,",
 													"    }];",
@@ -9200,7 +9200,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not object",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"RevocationList2020Status\",",
 													"        \"status\": {},",
 													"    }];",
@@ -9268,7 +9268,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be a valid value",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"RevocationList2020Status\",",
 													"        \"status\": \"invalid value\",",
 													"    }];",
@@ -9949,7 +9949,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus must be array, not boolean",
-													"    req.credentialstatus = false;",
+													"    req.credentialStatus = false;",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -10014,7 +10014,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus must be array, not integer",
-													"    req.credentialstatus = 42;",
+													"    req.credentialStatus = 42;",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -10079,7 +10079,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus must be array, not null",
-													"    req.credentialstatus = null;",
+													"    req.credentialStatus = null;",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -10144,7 +10144,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus must be array, not object",
-													"    req.credentialstatus = {",
+													"    req.credentialStatus = {",
 													"        \"type\": \"StatusList2021Entry\",",
 													"        \"statusPurpose\": \"revocation\",",
 													"        \"status\": \"0\"",
@@ -10213,7 +10213,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus must be array, not string",
-													"    req.credentialstatus = \"StatusList2021Entry\";",
+													"    req.credentialStatus = \"StatusList2021Entry\";",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -10278,7 +10278,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus can only have zero or one elements.",
-													"    req.credentialstatus = [",
+													"    req.credentialStatus = [",
 													"        {",
 													"            \"type\": \"StatusList2021Entry\",",
 													"            \"statusPurpose\": \"revocation\",",
@@ -10354,7 +10354,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus elements must be object, not array",
-													"    req.credentialstatus = [[]];",
+													"    req.credentialStatus = [[]];",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -10419,7 +10419,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus elements must be object, not boolean",
-													"    req.credentialstatus = [false];",
+													"    req.credentialStatus = [false];",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -10484,7 +10484,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus elements must be object, not integer",
-													"    req.credentialstatus = [42];",
+													"    req.credentialStatus = [42];",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -10549,7 +10549,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus elements must be object, not null",
-													"    req.credentialstatus = [null];",
+													"    req.credentialStatus = [null];",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -10614,7 +10614,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus elements must be object, not string",
-													"    req.credentialstatus = [\"StatusList2021Entry\"];",
+													"    req.credentialStatus = [\"StatusList2021Entry\"];",
 													"}));"
 												],
 												"type": "text/javascript"
@@ -10679,7 +10679,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item type is a required property",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"status\": \"0\",",
 													"    }];",
 													"}));"
@@ -10746,7 +10746,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item type must be string, not array",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": [\"StatusList2021Entry\"],",
 													"        \"statusPurpose\": \"revocation\",",
 													"        \"status\": \"0\",",
@@ -10815,7 +10815,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item type must be string, not boolean",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": false,",
 													"        \"status\": \"0\",",
 													"    }];",
@@ -10883,7 +10883,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item type must be string, not integer",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": 42,",
 													"        \"status\": \"0\",",
 													"    }];",
@@ -10951,7 +10951,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item type must be string, not null",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": null,",
 													"        \"status\": \"0\",",
 													"    }];",
@@ -11019,7 +11019,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item type must be string, not object",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": {},",
 													"        \"status\": \"0\",",
 													"    }];",
@@ -11087,7 +11087,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item type must be a valid value",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"invalid value\",",
 													"        \"status\": \"0\",",
 													"    }];",
@@ -11155,7 +11155,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status is a required property",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"StatusList2021Entry\",",
 													"        \"purpose\": \"revocation\",",
 													"    }];",
@@ -11223,7 +11223,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not array",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"StatusList2021Entry\",",
 													"        \"purpose\": \"revocation\",",
 													"        \"status\": [\"0\"],",
@@ -11292,7 +11292,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not boolean",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"StatusList2021Entry\",",
 													"        \"purpose\": \"revocation\",",
 													"        \"status\": false,",
@@ -11361,7 +11361,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not integer",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"StatusList2021Entry\",",
 													"        \"purpose\": \"revocation\",",
 													"        \"status\": 1,",
@@ -11430,7 +11430,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not null",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"StatusList2021Entry\",",
 													"        \"purpose\": \"revocation\",",
 													"        \"status\": null,",
@@ -11499,7 +11499,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not object",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"StatusList2021Entry\",",
 													"        \"purpose\": \"revocation\",",
 													"        \"status\": {},",
@@ -11568,7 +11568,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status is a required property",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"StatusList2021Entry\",",
 													"        \"status\": \"1\",",
 													"    }];",
@@ -11636,7 +11636,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not array",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"StatusList2021Entry\",",
 													"        \"purpose\": [\"revocation\"],",
 													"        \"status\": \"1\",",
@@ -11705,7 +11705,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not boolean",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"StatusList2021Entry\",",
 													"        \"purpose\": false,",
 													"        \"status\": \"1\",",
@@ -11774,7 +11774,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not integer",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"StatusList2021Entry\",",
 													"        \"purpose\": 42,",
 													"        \"status\": \"1\",",
@@ -11843,7 +11843,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not null",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"StatusList2021Entry\",",
 													"        \"purpose\": null,",
 													"        \"status\": \"1\",",
@@ -11912,7 +11912,7 @@
 												"exec": [
 													"pm.variables.set(\"requestBody\", mutateRequestBody((req) => {",
 													"    // credentialStatus item status must be string, not object",
-													"    req.credentialstatus = [{",
+													"    req.credentialStatus = [{",
 													"        \"type\": \"StatusList2021Entry\",",
 													"        \"purpose\": {},",
 													"        \"status\": \"1\",",


### PR DESCRIPTION
Replaced occurrences of `credentialstatus` with` credentialStatus` for the conformance prerequests. This was resulting in an incorrect key being used in the request for testing.