### PR TITLE
change collection link to use the StatusList2021 collection

### DIFF
--- a/.github/workflows/interoperability-report.yml
+++ b/.github/workflows/interoperability-report.yml
@@ -348,7 +348,7 @@ jobs:
           token_endpoint: ${{secrets[format('{0}_TOKEN_ENDPOINT', matrix.actor)]}}
           api_base_url: ${{secrets[format('{0}_API_BASE_URL', matrix.actor)]}}
         run: |
-          npx newman run ./docs/tutorials/credentials-revocation/credentials-revocation.postman_collection.json \
+          npx newman run ./docs/tutorials/credentials-status-update/credentials-status-update.postman_collection.json \
           --env-var ORGANIZATION_DID_WEB=$organization_did_web \
           --env-var CLIENT_ID=$client_id \
           --env-var CLIENT_SECRET=$client_secret \


### PR DESCRIPTION
This PR is related to #482. The interoperability reporting GA currently tests the RevocationList2020, I would like to propose a change test revocation with StatusList2021 instead.