### PR TITLE
VC Reference

### DIFF
--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -165,6 +165,10 @@
           authors: [	'Daniel Fett' , 'Kristina Yasuda' , 'Brian Campbell' ],
           status: "Draft",
         },
+        'VC-DATA-MODEL': {
+          title: 'W3C Verifiable Credentials Data Model v2.0',
+          href: 'https://www.w3.org/TR/2024/CR-vc-data-model-2.0-20240201/',
+        },
       },
     };
   </script>

--- a/docs/spec/sections/abstract.html
+++ b/docs/spec/sections/abstract.html
@@ -2,8 +2,8 @@
 <section id="abstract">
   <h2>Abstract</h2>
   <p>
-    This specification describes discovery and exchange mechanisms of [Verifiable
-    Credentials](https://www.w3.org/TR/vc-data-model-2.0/), particularly as they relate to supply chain use cases.
+    This specification describes discovery and exchange mechanisms of Verifiable
+    Credentials [[VC-DATA-MODEL]], particularly as they relate to supply chain use cases.
     Exchanged Verifiable Credentials often implement schemas defined in the [Traceability Vocab
     Specification](https://w3c-ccg.github.io/traceability-vocab/).
   </p>


### PR DESCRIPTION
The markdown reference in the abstract is broken. This fixes that, moving the reference to a proper biblio entry. 