### PR TITLE
642 assertionmethod section seems unnecessary

### DIFF
--- a/docs/spec/sections/use-case-requirements.html
+++ b/docs/spec/sections/use-case-requirements.html
@@ -188,7 +188,7 @@ See <a href="https://www.w3.org/TR/did-core/#assertion">assertionMethod</a>.
 </p>
 
 <p>
-  All <code>JsonWebKey</code> types support <code>application/vc+ld+jwt</code>.
+  All <code>JsonWebKey</code> types support securing with JOSE, as described in <a href="https://w3c.github.io/vc-jose-cose/#secure-with-jose">W3C VC-JOSE-COSE</a>.
 </p>
 
 <pre class="example">

--- a/docs/spec/sections/use-case-requirements.html
+++ b/docs/spec/sections/use-case-requirements.html
@@ -184,7 +184,6 @@ See <a href="https://www.w3.org/TR/did-core/#assertion">assertionMethod</a>.
 </p>
 
 <p>
-  All <code>Ed25519VerificationKey2018</code> types support <code>Ed25519Siganture2018</code>.
 </p>
 
 <p>

--- a/docs/spec/sections/use-case-requirements.html
+++ b/docs/spec/sections/use-case-requirements.html
@@ -153,27 +153,32 @@ Implementations are encouraged to require authentication for all endpoints.
 <p>
 See <a href="https://www.w3.org/TR/did-core/#assertion">assertionMethod</a>.
 </p>
+
 <p>
-  The entry MUST be present.
+  This entry MUST be present.
+</p>
+
+<p>
+  This entry MUST have at least one entry referencing an available <code>verificationMethod</code>.
 </p>
 
 </section>
 
 <section>
-  <h5>authentication</h5>
-<p>
-The set of supported <code>authentication</code> DID URLs for the organization.
-</p>
+  <h5>verificationMethod</h5>
+
+  <p>
+    The <code>verificationMethod</code> contains cryptographic material for public keys.
+  </p>
+
+  <p>
+    See <a href="https://www.w3.org/TR/did-core/#verification-methods">verificationMethod</a>.
+  </p>
 
 <p>
-See <a href="https://www.w3.org/TR/did-core/#authentication">authentication</a>.
+  The <code>didDocument</code> MUST contain at least one <code>verificationMethod</code> element.
 </p>
-</section>
 
- <p>
-  The <code>didDocument</code> MAY contain a <code>verificationMethod</code> section,
-  which MAY be used to support <code>did:web</code> based verification relationships.
- </p>
 <p>
   The <code>didDocument</code> MUST NOT contain <code>verificationMethods</code> where the controller is different from the DID Subject.
 </p>
@@ -186,10 +191,6 @@ See <a href="https://www.w3.org/TR/did-core/#authentication">authentication</a>.
   All <code>JsonWebKey</code> types support <code>application/vc+ld+jwt</code>.
 </p>
 
-<p>
-  In this example, the organization suports authentication and credential issuance with the same two keys, identified via the DID URLs in the relationships:
-</p>
-
 <pre class="example">
   {
     "@context": [
@@ -198,12 +199,19 @@ See <a href="https://www.w3.org/TR/did-core/#authentication">authentication</a>.
     ],
     "id": "did:web:platform.example:organization:123",
     "assertionMethod": [
-      "did:key:z6MksSdhqJH3VvzcX8WP6VbdB85e6T7aaL5yLLYeJLJrto8V#z6MksSdhqJH3VvzcX8WP6VbdB85e6T7aaL5yLLYeJLJrto8V",
-      "did:key:z82LkpR3sPw87xdgs72J3EzGXChciBmhV6ukkbeAGFtCpauXHiEwtM2tyDcphRnLmKsB1fi#z82LkpR3sPw87xdgs72J3EzGXChciBmhV6ukkbeAGFtCpauXHiEwtM2tyDcphRnLmKsB1fi"
+      "did:web:platform.example:organization:123#key1"
     ],
-     "authentication": [
-      "did:key:z6MksSdhqJH3VvzcX8WP6VbdB85e6T7aaL5yLLYeJLJrto8V#z6MksSdhqJH3VvzcX8WP6VbdB85e6T7aaL5yLLYeJLJrto8V",
-      "did:key:z82LkpR3sPw87xdgs72J3EzGXChciBmhV6ukkbeAGFtCpauXHiEwtM2tyDcphRnLmKsB1fi#z82LkpR3sPw87xdgs72J3EzGXChciBmhV6ukkbeAGFtCpauXHiEwtM2tyDcphRnLmKsB1fi"
+    "verificationMethod": [
+        {
+            "id": "did:web:platform.example:organization:123#key1",
+            "type": "JsonWebKey2020",
+            "controller": "did:web:platform.example:organization:123",
+            "publicKeyJwk": {
+                "kty": "OKP",
+                "crv": "Ed25519",
+                "x": "rfsiofZ3RcuMWZSoYbvNEZ_8oxeep8uapJDyT0ku8EM"
+            }
+        }
     ],
     "service": [
       {

--- a/docs/spec/sections/use-case-requirements.html
+++ b/docs/spec/sections/use-case-requirements.html
@@ -147,12 +147,16 @@ Implementations are encouraged to require authentication for all endpoints.
 <section>
   <h5>assertionMethod</h5>
 <p>
-The set of supported <code>assertionMethod</code> DID URLs for the organization.
+  The <code>assertionMethod</code> references public key material used by the organization for issuing Verifiable Credentials.
 </p>
 
 <p>
 See <a href="https://www.w3.org/TR/did-core/#assertion">assertionMethod</a>.
 </p>
+<p>
+  The entry MUST be present.
+</p>
+
 </section>
 
 <section>


### PR DESCRIPTION
- Removes the DID-based authentication
- Makes `assertionMethod` mandatory (at least one, referencing a `verficationMethod`)
- Makes `verificationMethod` mandatory (at least one)
- Replaces example `did:key` with `did:web`
- Adds `verificationMethod` to the example

Closes #642 
Closes #643 