### PR TITLE
fix: presentation authentication section

### DIFF
--- a/docs/spec/sections/authorization.html
+++ b/docs/spec/sections/authorization.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <section id="authorization" class="normative">
-  <h2>Authorization</h2>
+  <h2>Authentication</h2>
   <p>Implementations MUST support OAuth 2.0 Client Credentials based authorization.</p>
 
   <p>
@@ -29,13 +29,15 @@
   <section id="presentation-authentication">
     <h3>Presentation Authentication</h3>
     <p>
-      This API specification describes two ways in which presentations from a holder to a verifier can be authenticated:
+      The following sequence of events are required in order for a holder to present data to a verifier:
     </p>
     <ul>
       <li>
-        <a href="https://www.rfc-editor.org/rfc/rfc6749.html">OAuth 2.0</a>, where the verifier esablishes binding by
+        The verifier MUST establish the <a href="https://www.rfc-editor.org/rfc/rfc6749.html">OAuth 2.0</a> binding by
         providing client id and secret to the holder.
-        At time of presentation, the holder authenticates by obtaining an
+      </li>
+      <li>
+      At time of presentation, the holder MUST authenticates by obtaining an
         <a href="https://w3c-ccg.github.io/traceability-interop/openapi/#auth">access token</a> through the client
         credentials flow. Subsequent <a href="https://w3c-ccg.github.io/traceability-interop/openapi/#post-/presentations">
         presentations</a> are made with the access token in the request header.

--- a/docs/spec/sections/authorization.html
+++ b/docs/spec/sections/authorization.html
@@ -34,7 +34,7 @@
     <ul>
       <li>
         The verifier MUST establish the <a href="https://www.rfc-editor.org/rfc/rfc6749.html">OAuth 2.0</a> binding by
-        providing client id and secret to the holder.
+        providing client ID and secret to the holder.
       </li>
       <li>
       At time of presentation, the holder MUST authenticate by obtaining an

--- a/docs/spec/sections/authorization.html
+++ b/docs/spec/sections/authorization.html
@@ -29,7 +29,7 @@
   <section id="presentation-authentication">
     <h3>Presentation Authentication</h3>
     <p>
-      The following sequence of events are required in order for a holder to present data to a verifier:
+      The following sequence of events is necessary for a holder to present data to a verifier:
     </p>
     <ul>
       <li>

--- a/docs/spec/sections/authorization.html
+++ b/docs/spec/sections/authorization.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <section id="authorization" class="normative">
   <h2>Authentication</h2>
-  <p>Implementations MUST support OAuth 2.0 Client Credentials based authorization.</p>
+  <p>Implementations MUST support OAuth 2.0 Client Credentials based authentication.</p>
 
   <p>
     Client Credentials Grant is appropriate for verifying trusted application authorization for Internal/External APIs.

--- a/docs/spec/sections/authorization.html
+++ b/docs/spec/sections/authorization.html
@@ -37,7 +37,7 @@
         providing client id and secret to the holder.
       </li>
       <li>
-      At time of presentation, the holder MUST authenticates by obtaining an
+      At time of presentation, the holder MUST authenticate by obtaining an
         <a href="https://w3c-ccg.github.io/traceability-interop/openapi/#auth">access token</a> through the client
         credentials flow. Subsequent <a href="https://w3c-ccg.github.io/traceability-interop/openapi/#post-/presentations">
         presentations</a> are made with the access token in the request header.


### PR DESCRIPTION
This still had reminiscences of supporting multiple ways to authenticate. This should make it more readable. 

Title updated to Authentication, which is what the section is actually about. (Note that I have not updated references and file name to avoid merge collisions - to be updated in a later PR). 

Closes #644.